### PR TITLE
feat: add section 3 chart info [RWDQA-51]

### DIFF
--- a/src/components/annual-report/utils/utils.js
+++ b/src/components/annual-report/utils/utils.js
@@ -1,3 +1,10 @@
+export const sortArrayAfterIndex1 = (unsortedArray) => {
+    const unsortedItems = unsortedArray.slice(0, 1)
+    const sortedItems = unsortedArray.slice(1)
+    sortedItems.sort((a, b) => a.name.localeCompare(b.name))
+    return [...unsortedItems, ...sortedItems]
+}
+
 const getRowData = ({ headers, row }) => {
     const rowData = {}
     for (let i = 0; i < headers.length; i++) {


### PR DESCRIPTION
See: https://dhis2.atlassian.net/browse/RWDQA-51

This ticket is to add `chartInfo` for each item in Section 3A to be used for generating the chart.

Example first item from `Maternal Health, National, 2022`

```
{
    "section3a": [
        {
            "name": "ANC 1 coverage - routine and DHS",
            "level": 2,
            "qualityThreshold": 20,
            "surveyValue": 93,
            "routineValue": 87.6,
            "overallScore": 94.2,
            "divergentSubOrgUnits": {
                "number": 0,
                "percentage": 0,
                "names": "",
                "noncalculable": ""
            },
            "chartInfo": {
                "name": "ANC 1 coverage - routine and DHS",
                "type": "scatter",
                "values": [
                    {
                        "name": "National",
                        "survey": 93,
                        "routine": 87.6,
                        "divergent": false
                    },
                    {
                        "name": "Region A",
                        "survey": 90,
                        "routine": 85.6,
                        "divergent": false
                    },
                    {
                        "name": "Region B",
                        "survey": 92,
                        "routine": 88.4,
                        "divergent": false
                    },
                    {
                        "name": "Region C",
                        "survey": 97,
                        "routine": 86.6,
                        "divergent": false
                    },
                    {
                        "name": "Region D",
                        "survey": 94,
                        "routine": 88.9,
                        "divergent": false
                    }
                ]
            }
        }
    ]
}
```
