### PR TITLE
feat: generate charts for section 3 [RWDQA-14]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-10-26T11:52:21.650Z\n"
-"PO-Revision-Date: 2023-10-26T11:52:21.650Z\n"
+"POT-Creation-Date: 2023-11-02T09:47:40.459Z\n"
+"PO-Revision-Date: 2023-11-02T09:47:40.459Z\n"
 
 msgid "Select period(s)"
 msgstr "Select period(s)"
@@ -16,6 +16,21 @@ msgstr "Cancel"
 
 msgid "Save"
 msgstr "Save"
+
+msgid "No data to display"
+msgstr "No data to display"
+
+msgid "Chart not available"
+msgstr "Chart not available"
+
+msgid "Routine"
+msgstr "Routine"
+
+msgid "Survey"
+msgstr "Survey"
+
+msgid "Org units"
+msgstr "Org units"
 
 msgid "Group"
 msgstr "Group"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "@dhis2/multi-calendar-dates": "^1.0.2",
         "@dhis2/ui": "^8.14.9",
         "@dhis2/ui-core": "^6.24.0",
+        "highcharts": "^11.1.0",
         "react-router-dom": "^6.11.1",
         "regression": "^2.0.1"
     }

--- a/src/components/annual-report/generateChart.js
+++ b/src/components/annual-report/generateChart.js
@@ -2,7 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import H from 'highcharts'
 import HB from 'highcharts/modules/bullet'
 import HNDTD from 'highcharts/modules/no-data-to-display'
-//import { generateSection3Chart } from './section3/section3ChartGenerator.js'
+import { generateSection3Chart } from './section3/section3ChartGenerator.js'
 import { generateSection4Chart } from './section4/section4ChartGenerator.js'
 
 // init Highcharts
@@ -63,7 +63,7 @@ export const generateChart = (sectionId, canvasId, chartInfo) => {
 
     switch (sectionId) {
         case 'section3': {
-            //chartConfig = generateSection3Chart(canvasId, chartInfo)
+            chartConfig = generateSection3Chart(canvasId, chartInfo)
             break
         }
         case 'section4': {

--- a/src/components/annual-report/generateChart.js
+++ b/src/components/annual-report/generateChart.js
@@ -73,6 +73,7 @@ export const generateChart = (sectionId, canvasId, chartInfo) => {
     }
 
     return new H.Chart({
+        // global settings
         accessibility: {
             enabled: false,
         },
@@ -85,7 +86,6 @@ export const generateChart = (sectionId, canvasId, chartInfo) => {
         title: {
             text: null,
         },
-
         // specific settings
         ...chartConfig,
     })

--- a/src/components/annual-report/section3/SectionThree.js
+++ b/src/components/annual-report/section3/SectionThree.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { calculateSection3 } from './section3Calculations.js'
+import { generateChart } from './section3ChartGenerator.js'
 import { useFetchSectionThreeData } from './useFetchSectionThreeData.js'
 
 const isNotMissing = (val) => val !== undefined && val !== null
@@ -31,6 +32,19 @@ SubSectionLayout.propTypes = {
     title: PropTypes.string,
 }
 
+const Chart = ({ chartId, chartInfo }) => {
+    useEffect(() => {
+        generateChart(chartId, chartInfo)
+    }, [chartId, chartInfo])
+
+    return <div id={chartId} />
+}
+
+Chart.propTypes = {
+    chartId: PropTypes.string.isRequired,
+    chartInfo: PropTypes.object.isRequired,
+}
+
 const Section3A = ({ title, subtitle, subsectionData }) => (
     <>
         <table>
@@ -40,61 +54,79 @@ const Section3A = ({ title, subtitle, subsectionData }) => (
         </table>
         {subsectionData
             .sort((a, b) => a.name.localeCompare(b.name))
-            .map((dataRow) => (
-                <table key={dataRow.name}>
-                    <thead>
-                        <tr>
-                            <th>{dataRow.name}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>Survey value</td>
-                            <td>{dataRow.surveyValue}%</td>
-                        </tr>
-                        <tr>
-                            <td>Routine value</td>
-                            <td>{dataRow.routineValue}%</td>
-                        </tr>
-                        <tr>
-                            <td>Quality threshold</td>
-                            <td>± {dataRow.qualityThreshold}%</td>
-                        </tr>
-                        <tr>
-                            <td>Overall score</td>
-                            <td>{dataRow.overallScore}%</td>
-                        </tr>
-                        <tr>
-                            <td>Number of Region with divergent score</td>
-                            <td>
-                                {isNotMissing(
-                                    dataRow.divergentSubOrgUnits?.number
-                                )
-                                    ? dataRow.divergentSubOrgUnits?.number
-                                    : 'Not available'}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>% Region with poor score</td>
-                            <td>
-                                {isNotMissing(
-                                    dataRow.divergentSubOrgUnits?.percentage
-                                )
-                                    ? dataRow.divergentSubOrgUnits?.percentage +
-                                      '%'
-                                    : 'Not available'}
-                            </td>
-                        </tr>
-                        {dataRow.divergentSubOrgUnits?.names?.length > 0 && (
-                            <tr>
-                                <td colSpan="2">
-                                    {dataRow.divergentSubOrgUnits?.names}
-                                </td>
-                            </tr>
-                        )}
-                    </tbody>
-                </table>
-            ))}
+            .map((dataRow, index) => {
+                const chartId = `section3a-chart${index}`
+
+                return (
+                    <>
+                        <table key={dataRow.name}>
+                            <thead>
+                                <tr>
+                                    <th>{dataRow.name}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Survey value</td>
+                                    <td>{dataRow.surveyValue}%</td>
+                                </tr>
+                                <tr>
+                                    <td>Routine value</td>
+                                    <td>{dataRow.routineValue}%</td>
+                                </tr>
+                                <tr>
+                                    <td>Quality threshold</td>
+                                    <td>± {dataRow.qualityThreshold}%</td>
+                                </tr>
+                                <tr>
+                                    <td>Overall score</td>
+                                    <td>{dataRow.overallScore}%</td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        Number of Region with divergent score
+                                    </td>
+                                    <td>
+                                        {isNotMissing(
+                                            dataRow.divergentSubOrgUnits?.number
+                                        )
+                                            ? dataRow.divergentSubOrgUnits
+                                                  ?.number
+                                            : 'Not available'}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>% Region with poor score</td>
+                                    <td>
+                                        {isNotMissing(
+                                            dataRow.divergentSubOrgUnits
+                                                ?.percentage
+                                        )
+                                            ? dataRow.divergentSubOrgUnits
+                                                  ?.percentage + '%'
+                                            : 'Not available'}
+                                    </td>
+                                </tr>
+                                {dataRow.divergentSubOrgUnits?.names?.length >
+                                    0 && (
+                                    <tr>
+                                        <td colSpan="2">
+                                            {
+                                                dataRow.divergentSubOrgUnits
+                                                    ?.names
+                                            }
+                                        </td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                        <Chart
+                            chartId={chartId}
+                            chartInfo={dataRow.chartInfo}
+                        />
+                    </>
+                )
+            })}
     </>
 )
 

--- a/src/components/annual-report/section3/SectionThree.js
+++ b/src/components/annual-report/section3/SectionThree.js
@@ -43,8 +43,8 @@ const Section3A = ({ title, subtitle, subsectionData }) => (
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((dataRow, index) => {
                 return (
-                    <>
-                        <table key={dataRow.name}>
+                    <React.Fragment key={dataRow.name}>
+                        <table>
                             <thead>
                                 <tr>
                                     <th>{dataRow.name}</th>
@@ -110,7 +110,7 @@ const Section3A = ({ title, subtitle, subsectionData }) => (
                             chartId={`chart${index}`}
                             chartInfo={dataRow.chartInfo}
                         />
-                    </>
+                    </React.Fragment>
                 )
             })}
     </>

--- a/src/components/annual-report/section3/SectionThree.js
+++ b/src/components/annual-report/section3/SectionThree.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
+import { Chart } from '../Chart.js'
 import { calculateSection3 } from './section3Calculations.js'
-import { generateChart } from './section3ChartGenerator.js'
 import { useFetchSectionThreeData } from './useFetchSectionThreeData.js'
 
 const isNotMissing = (val) => val !== undefined && val !== null
@@ -32,19 +32,6 @@ SubSectionLayout.propTypes = {
     title: PropTypes.string,
 }
 
-const Chart = ({ chartId, chartInfo }) => {
-    useEffect(() => {
-        generateChart(chartId, chartInfo)
-    }, [chartId, chartInfo])
-
-    return <div id={chartId} />
-}
-
-Chart.propTypes = {
-    chartId: PropTypes.string.isRequired,
-    chartInfo: PropTypes.object.isRequired,
-}
-
 const Section3A = ({ title, subtitle, subsectionData }) => (
     <>
         <table>
@@ -55,8 +42,6 @@ const Section3A = ({ title, subtitle, subsectionData }) => (
         {subsectionData
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((dataRow, index) => {
-                const chartId = `section3a-chart${index}`
-
                 return (
                     <>
                         <table key={dataRow.name}>
@@ -121,7 +106,8 @@ const Section3A = ({ title, subtitle, subsectionData }) => (
                             </tbody>
                         </table>
                         <Chart
-                            chartId={chartId}
+                            sectionId={'section3'}
+                            chartId={`chart${index}`}
                             chartInfo={dataRow.chartInfo}
                         />
                     </>

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -132,27 +132,29 @@ const generateScatterChartConfig = (chartId, chartInfo) => {
         data: [],
     }
 
-    chartInfo.values.forEach(({ routine, survey, divergent }) => {
-        routineSeries.data.push({
-            y: routine,
-            custom: {
-                survey,
-            },
-            marker: {
-                symbol: divergent ? 'triangle' : 'plus',
-            },
-        })
+    chartInfo.values
+        .filter(({ invalid }) => !invalid)
+        .forEach(({ routine, survey, divergent }) => {
+            routineSeries.data.push({
+                y: routine,
+                custom: {
+                    survey,
+                },
+                marker: {
+                    symbol: divergent ? 'triangle' : 'plus',
+                },
+            })
 
-        surveySeries.data.push({
-            y: survey,
-            custom: {
-                routine,
-            },
-            marker: {
-                symbol: divergent ? 'triangle-down' : 'circle',
-            },
+            surveySeries.data.push({
+                y: survey,
+                custom: {
+                    routine,
+                },
+                marker: {
+                    symbol: divergent ? 'triangle-down' : 'circle',
+                },
+            })
         })
-    })
 
     return {
         chart: {

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -63,13 +63,18 @@ const generateBulletChartConfig = (canvasId, chartInfo) => ({
                 {
                     y: chartInfo.values[0].routine,
                     target: chartInfo.values[0].survey,
+                    custom: {
+                        name: chartInfo.values[0].name,
+                    },
                 },
             ],
         },
     ],
     tooltip: {
-        headerFormat: '<b>National</b><br/>',
-        pointFormat: 'Survey: {point.target}%<br/>Routine: {point.y}%',
+        headerFormat: '',
+        pointFormatter: function () {
+            return `<b>${this.custom.name}</b><br/>Survey: ${this.target}%<br/>Routine: ${this.y}%`
+        },
     },
 })
 

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import H from 'highcharts'
 
 export const generateSection3Chart = (canvasId, chartInfo) => {
@@ -9,6 +10,16 @@ export const generateSection3Chart = (canvasId, chartInfo) => {
             break
         case 'scatter':
             chartConfig = generateScatterChartConfig(canvasId, chartInfo)
+            break
+        default:
+            chartConfig = {
+                chart: {
+                    renderTo: canvasId,
+                },
+                lang: {
+                    noData: i18n.t('Chart not available'),
+                },
+            }
             break
     }
 

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -1,18 +1,13 @@
 import i18n from '@dhis2/d2-i18n'
-import H from 'highcharts'
 
 export const generateSection3Chart = (canvasId, chartInfo) => {
-    let chartConfig
-
     switch (chartInfo.type) {
         case 'bullet':
-            chartConfig = generateBulletChartConfig(canvasId, chartInfo)
-            break
+            return generateBulletChartConfig(canvasId, chartInfo)
         case 'scatter':
-            chartConfig = generateScatterChartConfig(canvasId, chartInfo)
-            break
+            return generateScatterChartConfig(canvasId, chartInfo)
         default:
-            chartConfig = {
+            return {
                 chart: {
                     renderTo: canvasId,
                 },
@@ -20,26 +15,7 @@ export const generateSection3Chart = (canvasId, chartInfo) => {
                     noData: i18n.t('Chart not available'),
                 },
             }
-            break
     }
-
-    return new H.Chart({
-        // global settings
-        accessibility: {
-            enabled: false,
-        },
-        credits: {
-            enabled: false,
-        },
-        exporting: {
-            enabled: false,
-        },
-        title: {
-            text: null,
-        },
-        // specific settings
-        ...chartConfig,
-    })
 }
 
 const generateBulletChartConfig = (canvasId, chartInfo) => {

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -85,7 +85,14 @@ const generateBulletChartConfig = (canvasId, chartInfo) => {
         tooltip: {
             headerFormat: '',
             pointFormatter: function () {
-                return `<b>${this.custom.name}</b><br/>Survey: ${this.target}%<br/>Routine: ${this.y}%`
+                return i18n.t(
+                    '<b>{{name}}</b><br/>Survey: {{survey}}%<br/>Routine: {{routine}}%',
+                    {
+                        name: this.custom.name,
+                        survey: this.target,
+                        routine: this.y,
+                    }
+                )
             },
         },
     }
@@ -93,12 +100,12 @@ const generateBulletChartConfig = (canvasId, chartInfo) => {
 
 const generateScatterChartConfig = (canvasId, chartInfo) => {
     const routineSeries = {
-        name: 'Routine',
+        name: i18n.t('Routine'),
         color: 'blue',
         data: [],
     }
     const surveySeries = {
-        name: 'Survey',
+        name: i18n.t('Survey'),
         color: 'red',
         data: [],
     }
@@ -146,8 +153,10 @@ const generateScatterChartConfig = (canvasId, chartInfo) => {
         tooltip: {
             headerFormat: '<b>{point.key}</b><br/>',
             pointFormatter: function () {
-                return `Survey: ${(this.custom.survey ??=
-                    this.y)}%<br/>Routine: ${(this.custom.routine ??= this.y)}%`
+                return i18n.t('Survey: {{survey}}%<br/>Routine: {{routine}}%', {
+                    survey: this.custom.survey ?? this.y,
+                    routine: this.custom.routine ?? this.y,
+                })
             },
         },
         plotOptions: {

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -1,61 +1,14 @@
 import H from 'highcharts'
-import HB from 'highcharts/modules/bullet'
 
-// init Highcharts
-// eslint-disable-next-line max-params
-H.SVGRenderer.prototype.symbols.plus = (x, y, w, h) => [
-    'M',
-    x,
-    y + (5 * h) / 8,
-    'L',
-    x,
-    y + (3 * h) / 8,
-    'L',
-    x + (3 * w) / 8,
-    y + (3 * h) / 8,
-    'L',
-    x + (3 * w) / 8,
-    y,
-    'L',
-    x + (5 * w) / 8,
-    y,
-    'L',
-    x + (5 * w) / 8,
-    y + (3 * h) / 8,
-    'L',
-    x + w,
-    y + (3 * h) / 8,
-    'L',
-    x + w,
-    y + (5 * h) / 8,
-    'L',
-    x + (5 * w) / 8,
-    y + (5 * h) / 8,
-    'L',
-    x + (5 * w) / 8,
-    y + h,
-    'L',
-    x + (3 * w) / 8,
-    y + h,
-    'L',
-    x + (3 * w) / 8,
-    y + (5 * h) / 8,
-    'L',
-    x,
-    y + (5 * h) / 8,
-    'z',
-]
-HB(H)
-
-export const generateChart = (chartId, chartInfo) => {
+export const generateSection3Chart = (canvasId, chartInfo) => {
     let chartConfig
 
     switch (chartInfo.type) {
         case 'bullet':
-            chartConfig = generateBulletChartConfig(chartId, chartInfo)
+            chartConfig = generateBulletChartConfig(canvasId, chartInfo)
             break
         case 'scatter':
-            chartConfig = generateScatterChartConfig(chartId, chartInfo)
+            chartConfig = generateScatterChartConfig(canvasId, chartInfo)
             break
     }
 
@@ -78,9 +31,9 @@ export const generateChart = (chartId, chartInfo) => {
     })
 }
 
-const generateBulletChartConfig = (chartId, chartInfo) => ({
+const generateBulletChartConfig = (canvasId, chartInfo) => ({
     chart: {
-        renderTo: chartId,
+        renderTo: canvasId,
         type: 'bullet',
         inverted: true,
         height: 115,
@@ -120,7 +73,7 @@ const generateBulletChartConfig = (chartId, chartInfo) => ({
     },
 })
 
-const generateScatterChartConfig = (chartId, chartInfo) => {
+const generateScatterChartConfig = (canvasId, chartInfo) => {
     const routineSeries = {
         name: 'Routine',
         color: 'blue',
@@ -158,7 +111,7 @@ const generateScatterChartConfig = (chartId, chartInfo) => {
 
     return {
         chart: {
-            renderTo: chartId,
+            renderTo: canvasId,
             type: 'scatter',
         },
         xAxis: {

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -1,0 +1,186 @@
+import H from 'highcharts'
+import HB from 'highcharts/modules/bullet'
+
+// init Highcharts
+// eslint-disable-next-line max-params
+H.SVGRenderer.prototype.symbols.plus = (x, y, w, h) => [
+    'M',
+    x,
+    y + (5 * h) / 8,
+    'L',
+    x,
+    y + (3 * h) / 8,
+    'L',
+    x + (3 * w) / 8,
+    y + (3 * h) / 8,
+    'L',
+    x + (3 * w) / 8,
+    y,
+    'L',
+    x + (5 * w) / 8,
+    y,
+    'L',
+    x + (5 * w) / 8,
+    y + (3 * h) / 8,
+    'L',
+    x + w,
+    y + (3 * h) / 8,
+    'L',
+    x + w,
+    y + (5 * h) / 8,
+    'L',
+    x + (5 * w) / 8,
+    y + (5 * h) / 8,
+    'L',
+    x + (5 * w) / 8,
+    y + h,
+    'L',
+    x + (3 * w) / 8,
+    y + h,
+    'L',
+    x + (3 * w) / 8,
+    y + (5 * h) / 8,
+    'L',
+    x,
+    y + (5 * h) / 8,
+    'z',
+]
+HB(H)
+
+export const generateChart = (chartId, chartInfo) => {
+    let chartConfig
+
+    switch (chartInfo.type) {
+        case 'bullet':
+            chartConfig = generateBulletChartConfig(chartId, chartInfo)
+            break
+        case 'scatter':
+            chartConfig = generateScatterChartConfig(chartId, chartInfo)
+            break
+    }
+
+    return new H.Chart({
+        // global settings
+        accessibility: {
+            enabled: false,
+        },
+        credits: {
+            enabled: false,
+        },
+        exporting: {
+            enabled: false,
+        },
+        title: {
+            text: null,
+        },
+        // specific settings
+        ...chartConfig,
+    })
+}
+
+const generateBulletChartConfig = (chartId, chartInfo) => ({
+    chart: {
+        renderTo: chartId,
+        type: 'bullet',
+        inverted: true,
+        height: 115,
+    },
+    legend: {
+        enabled: false,
+    },
+    xAxis: {
+        categories: [chartInfo.name],
+    },
+    yAxis: {
+        gridLineWidth: 0,
+        plotBands: [
+            {
+                from: 0,
+                to: 100,
+                color: '#bababa',
+            },
+        ],
+        title: null,
+    },
+    series: [
+        {
+            color: '#1f77b4',
+            borderWidth: 0,
+            data: [
+                {
+                    y: chartInfo.values[0].routine,
+                    target: chartInfo.values[0].survey,
+                },
+            ],
+        },
+    ],
+    tooltip: {
+        headerFormat: '<b>National</b><br/>',
+        pointFormat: 'Survey: {point.target}%<br/>Routine: {point.y}%',
+    },
+})
+
+const generateScatterChartConfig = (chartId, chartInfo) => {
+    const routineSeries = {
+        name: 'Routine',
+        color: 'blue',
+        data: [],
+    }
+    const surveySeries = {
+        name: 'Survey',
+        color: 'red',
+        data: [],
+    }
+
+    chartInfo.values.forEach(({ routine, survey, divergent }) => {
+        routineSeries.data.push({
+            y: routine,
+            custom: {
+                survey,
+            },
+            marker: {
+                symbol: divergent ? 'triangle' : 'plus',
+            },
+        })
+
+        surveySeries.data.push({
+            y: survey,
+            custom: {
+                routine,
+            },
+            marker: {
+                symbol: divergent ? 'triangle-down' : 'circle',
+            },
+        })
+    })
+
+    return {
+        chart: {
+            renderTo: chartId,
+            type: 'scatter',
+        },
+        xAxis: {
+            categories: chartInfo.values.map(({ name }) => name),
+        },
+        yAxis: {
+            title: {
+                enabled: false,
+            },
+        },
+        series: [routineSeries, surveySeries],
+        tooltip: {
+            headerFormat: '<b>{point.key}</b><br/>',
+            pointFormatter: function () {
+                return `Survey: ${(this.custom.survey ??=
+                    this.y)}%<br/>Routine: ${(this.custom.routine ??= this.y)}%`
+            },
+        },
+        plotOptions: {
+            series: {
+                marker: {
+                    symbol: 'circle',
+                },
+            },
+        },
+    }
+}

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -42,52 +42,54 @@ export const generateSection3Chart = (canvasId, chartInfo) => {
     })
 }
 
-const generateBulletChartConfig = (canvasId, chartInfo) => ({
-    chart: {
-        renderTo: canvasId,
-        type: 'bullet',
-        inverted: true,
-        height: 115,
-    },
-    legend: {
-        enabled: false,
-    },
-    xAxis: {
-        categories: [chartInfo.name],
-    },
-    yAxis: {
-        gridLineWidth: 0,
-        plotBands: [
-            {
-                from: 0,
-                to: 100,
-                color: '#bababa',
-            },
-        ],
-        title: null,
-    },
-    series: [
-        {
-            color: '#1f77b4',
-            borderWidth: 0,
-            data: [
+const generateBulletChartConfig = (canvasId, chartInfo) => {
+    const data = chartInfo.values.map(({ routine, survey, name }) => ({
+        y: routine,
+        target: survey,
+        custom: {
+            name,
+        },
+    }))
+
+    return {
+        chart: {
+            renderTo: canvasId,
+            type: 'bullet',
+            inverted: true,
+            height: 115,
+        },
+        legend: {
+            enabled: false,
+        },
+        xAxis: {
+            categories: [chartInfo.name],
+        },
+        yAxis: {
+            gridLineWidth: 0,
+            plotBands: [
                 {
-                    y: chartInfo.values[0].routine,
-                    target: chartInfo.values[0].survey,
-                    custom: {
-                        name: chartInfo.values[0].name,
-                    },
+                    from: 0,
+                    to: 100,
+                    color: '#bababa',
                 },
             ],
+            title: null,
         },
-    ],
-    tooltip: {
-        headerFormat: '',
-        pointFormatter: function () {
-            return `<b>${this.custom.name}</b><br/>Survey: ${this.target}%<br/>Routine: ${this.y}%`
+        series: [
+            {
+                color: '#1f77b4',
+                borderWidth: 0,
+                data,
+            },
+        ],
+        tooltip: {
+            headerFormat: '',
+            pointFormatter: function () {
+                return `<b>${this.custom.name}</b><br/>Survey: ${this.target}%<br/>Routine: ${this.y}%`
+            },
         },
-    },
-})
+    }
+}
 
 const generateScatterChartConfig = (canvasId, chartInfo) => {
     const routineSeries = {

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -166,6 +166,8 @@ const generateScatterChartConfig = (chartId, chartInfo) => {
             title: {
                 enabled: false,
             },
+            min: 0,
+            softMax: 100,
         },
         series: [routineSeries, surveySeries],
         tooltip: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7794,6 +7794,11 @@ highcharts@^10.2.0:
   resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-10.3.3.tgz#b8acca24f2d4b1f2f726540734166e59e07b35c4"
   integrity sha512-r7wgUPQI9tr3jFDn3XT36qsNwEIZYcfgz4mkKEA6E4nn5p86y+u1EZjazIG4TRkl5/gmGRtkBUiZW81g029RIw==
 
+highcharts@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-11.1.0.tgz#715eb55fd081351b526e28cd89ac0e4e30b35c15"
+  integrity sha512-vhmqq6/frteWMx0GKYWwEFL25g4OYc7+m+9KQJb/notXbNtIb8KVy+ijOF7XAFqF165cq0pdLIePAmyFY5ph3g==
+
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"


### PR DESCRIPTION
This PR (for ticket https://dhis2.atlassian.net/browse/RWDQA-14)

- adds Highcharts dependency to the app
- implements a component and some functions for generating charts (scatter and bullet) needed in Section 3
- handle invalid `chartInfo.type` case: empty chart with "Chart not available" text is shown
- handle empty `chartInfo.values` case: chart with "No data to display" text is shown

Chart screenshots:
Scatter chart showing plus marker for Routine:
<img width="1441" alt="Screenshot 2023-10-31 at 11 56 16" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/0998bbfe-dea8-4440-90a1-806473dda42e">

Scatter chart showing triangle markers for divergent values and tooltip:
<img width="1440" alt="Screenshot 2023-10-31 at 11 56 29" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/2f178500-e622-49a8-ab1a-a348340ed3a1">

Bullet chart:
<img width="1443" alt="Screenshot 2023-10-31 at 11 59 09" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/f8d15531-d161-46a6-a21a-8823f893af5c">

<img width="1440" alt="Screenshot 2023-10-31 at 11 56 37" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/47766eea-0071-419d-b3b5-3bc583cf9f92">

