### PR TITLE
feat: add info for Section 4 charts [RWDQA-52]

### DIFF
--- a/src/components/annual-report/report-data/section4/section4Calculations.js
+++ b/src/components/annual-report/report-data/section4/section4Calculations.js
@@ -46,8 +46,11 @@ const calculateSection4a = ({
 const get4BScore = ({ response, aID, bID, ou, pe }) => {
     const aVal = getVal({ response, dx: aID, ou, pe })
     const bVal = getVal({ response, dx: bID, ou, pe })
-    return aVal / bVal
+    return { aVal, bVal, score: aVal / bVal }
 }
+
+const isDivergent4b = ({ score, criteria }) =>
+    score > 1 + criteria / 100 || score < 1 - criteria / 100
 
 const calculateSection4b = ({
     unformattedIndResponse,
@@ -57,7 +60,7 @@ const calculateSection4b = ({
     overallOrgUnit,
 }) => {
     const metadata = unformattedIndResponse.metaData.items
-    const overallScore = get4BScore({
+    const { score: overallScore } = get4BScore({
         response: formattedResponseOverall,
         aID: relation.A.id,
         bID: relation.B.id,
@@ -70,6 +73,12 @@ const calculateSection4b = ({
         A: metadata[relation.A.id]?.name,
         B: metadata[relation.B.id]?.name,
         qualityThreshold: relation.criteria,
+        chartInfo: {
+            x: metadata[relation.B.id]?.name,
+            y: metadata[relation.A.id]?.name,
+            threshold: relation.criteria,
+            values: [],
+        },
     }
     // return early if overallScore is invalid
     if (isNaN(overallScore)) {
@@ -85,20 +94,31 @@ const calculateSection4b = ({
     const divergentSubOrgUnits = []
 
     for (const subOrgUnitID of subOrgUnits) {
-        const subOrgUnitScore = get4BScore({
+        const {
+            score: subOrgUnitScore,
+            aVal,
+            bVal,
+        } = get4BScore({
             response: formattedIndResponse,
             aID: relation.A.id,
             bID: relation.B.id,
             ou: subOrgUnitID,
             pe: currentPeriodID,
         })
-
-        if (
-            subOrgUnitScore > 1 + relation.criteria / 100 ||
-            subOrgUnitScore < 1 - relation.criteria / 100
-        ) {
+        const divergent = isDivergent4b({
+            score: subOrgUnitScore,
+            criteria: relation.criteria,
+        })
+        if (divergent) {
             divergentSubOrgUnits.push(subOrgUnitID)
         }
+        fourBItem.chartInfo.values.push({
+            x: bVal,
+            y: aVal,
+            name: metadata[subOrgUnitID]?.name,
+            divergent,
+            invalid: isNaN(subOrgUnitScore),
+        })
     }
 
     return {

--- a/src/components/annual-report/report-data/section4/section4Calculations.js
+++ b/src/components/annual-report/report-data/section4/section4Calculations.js
@@ -117,7 +117,7 @@ const calculateSection4b = ({
             y: aVal,
             name: metadata[subOrgUnitID]?.name,
             divergent,
-            invalid: isNaN(subOrgUnitScore),
+            invalid: isNaN(aVal) || isNaN(bVal),
         })
     }
 


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/RWDQA-52

This PR adds chartInfo in the format discussed on the ticket (see below) 

I've also added a `invalid` property to denote values where the calculations are invalid (these values can be skipped in chart generation).

TBD: the old app does not display a chart if the level of the numerator relation matches the level of the selected Org Unit (boundary org unit). We need to clarify with Olav on what the desired behaviour is here. The old app is skipping the chart here, though theoretically, it could just be generated with the one data point. I think it's probably easier to just generate the chart if we have the one data point. (see https://dhis2.slack.com/archives/C053JT69YD8/p1698330063957719)

**Sample Section4b (Maternal Health > National > 2022)**
```
[
    {
        "overallScore": 141.6,
        "name": "Population < 1 year - HMIS vs EPI",
        "A": "Population < 1 years",
        "B": "Population < 1 years (EPI)",
        "qualityThreshold": 10,
        "chartInfo": {
            "x": "Population < 1 years (EPI)",
            "y": "Population < 1 years",
            "threshold": 10,
            "values": [
                {
                    "x": 78445,
                    "y": 78268,
                    "name": "Region A",
                    "divergent": false,
                    "invalid": false
                },
                {
                    "x": 94811,
                    "y": 95802,
                    "name": "Region B",
                    "divergent": false,
                    "invalid": false
                },
                {
                    "x": 125815,
                    "y": 178000,
                    "name": "Region C",
                    "divergent": true,
                    "invalid": false
                },
                {
                    "x": 75384,
                    "y": 178131,
                    "name": "Region D",
                    "divergent": true,
                    "invalid": false
                }
            ]
        },
        "divergentSubOrgUnits": {
            "names": "Region C, Region D",
            "percentage": 50,
            "number": 2
        }
    },
    {
        "overallScore": 0.1,
        "name": "morbid test",
        "A": "Maternal deaths (Maternity)",
        "B": "Live births",
        "qualityThreshold": 10,
        "chartInfo": {
            "x": "Live births",
            "y": "Maternal deaths (Maternity)",
            "threshold": 10,
            "values": [
                {
                    "x": 374307,
                    "y": 501,
                    "name": "National",
                    "divergent": true,
                    "invalid": false
                }
            ]
        },
        "divergentSubOrgUnits": {
            "names": "National",
            "percentage": 100,
            "number": 1
        }
    }
]
```
