### PR TITLE
feat: generate charts for section4 [RWDQA-14]

### DIFF
--- a/src/components/annual-report/Chart.js
+++ b/src/components/annual-report/Chart.js
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types'
+import React, { useEffect } from 'react'
+import { generateChart } from './generateChart.js'
+
+export const Chart = ({ sectionId, chartId, chartInfo }) => {
+    const canvasId = `${sectionId}-${chartId}`
+
+    useEffect(() => {
+        generateChart(sectionId, canvasId, chartInfo)
+    }, [sectionId, canvasId, chartInfo])
+
+    return <div id={canvasId} />
+}
+
+Chart.propTypes = {
+    chartId: PropTypes.string.isRequired,
+    chartInfo: PropTypes.object.isRequired,
+    sectionId: PropTypes.string.isRequired,
+}

--- a/src/components/annual-report/generateChart.js
+++ b/src/components/annual-report/generateChart.js
@@ -1,0 +1,84 @@
+import H from 'highcharts'
+import HB from 'highcharts/modules/bullet'
+//import { generateSection3Chart } from './section3/section3ChartGenerator.js'
+import { generateSection4Chart } from './report-data/section4/section4ChartGenerator.js'
+
+// init Highcharts
+// eslint-disable-next-line max-params
+H.SVGRenderer.prototype.symbols.plus = (x, y, w, h) => [
+    'M',
+    x,
+    y + (5 * h) / 8,
+    'L',
+    x,
+    y + (3 * h) / 8,
+    'L',
+    x + (3 * w) / 8,
+    y + (3 * h) / 8,
+    'L',
+    x + (3 * w) / 8,
+    y,
+    'L',
+    x + (5 * w) / 8,
+    y,
+    'L',
+    x + (5 * w) / 8,
+    y + (3 * h) / 8,
+    'L',
+    x + w,
+    y + (3 * h) / 8,
+    'L',
+    x + w,
+    y + (5 * h) / 8,
+    'L',
+    x + (5 * w) / 8,
+    y + (5 * h) / 8,
+    'L',
+    x + (5 * w) / 8,
+    y + h,
+    'L',
+    x + (3 * w) / 8,
+    y + h,
+    'L',
+    x + (3 * w) / 8,
+    y + (5 * h) / 8,
+    'L',
+    x,
+    y + (5 * h) / 8,
+    'z',
+]
+HB(H)
+
+export const generateChart = (sectionId, canvasId, chartInfo) => {
+    let chartConfig
+
+    switch (sectionId) {
+        case 'section3': {
+            //generateSection3Chart(canvasId, chartInfo)
+            break
+        }
+        case 'section4': {
+            chartConfig = generateSection4Chart(canvasId, chartInfo)
+            break
+        }
+    }
+
+    console.log('chartconfig', chartConfig)
+    return new H.Chart({
+        accessibility: {
+            enabled: false,
+        },
+        credits: {
+            enabled: false,
+        },
+        exporting: {
+            enabled: false,
+        },
+        title: {
+            text: null,
+        },
+
+        // specific settings
+        ...chartConfig,
+    })
+}

--- a/src/components/annual-report/generateChart.js
+++ b/src/components/annual-report/generateChart.js
@@ -1,7 +1,9 @@
+import i18n from '@dhis2/d2-i18n'
 import H from 'highcharts'
 import HB from 'highcharts/modules/bullet'
+import HNDTD from 'highcharts/modules/no-data-to-display'
 //import { generateSection3Chart } from './section3/section3ChartGenerator.js'
-import { generateSection4Chart } from './report-data/section4/section4ChartGenerator.js'
+import { generateSection4Chart } from './section4/section4ChartGenerator.js'
 
 // init Highcharts
 // eslint-disable-next-line max-params
@@ -48,13 +50,20 @@ H.SVGRenderer.prototype.symbols.plus = (x, y, w, h) => [
     'z',
 ]
 HB(H)
+HNDTD(H)
+
+H.setOptions({
+    lang: {
+        noData: i18n.t('No data to display'),
+    },
+})
 
 export const generateChart = (sectionId, canvasId, chartInfo) => {
     let chartConfig
 
     switch (sectionId) {
         case 'section3': {
-            //generateSection3Chart(canvasId, chartInfo)
+            //chartConfig = generateSection3Chart(canvasId, chartInfo)
             break
         }
         case 'section4': {

--- a/src/components/annual-report/generateChart.js
+++ b/src/components/annual-report/generateChart.js
@@ -72,7 +72,6 @@ export const generateChart = (sectionId, canvasId, chartInfo) => {
         }
     }
 
-    console.log('chartconfig', chartConfig)
     return new H.Chart({
         accessibility: {
             enabled: false,

--- a/src/components/annual-report/section4/SectionFour.js
+++ b/src/components/annual-report/section4/SectionFour.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import { Chart } from '../../Chart.js'
+import { Chart } from '../Chart.js'
 import { calculateSection4 } from './section4Calculations.js'
 import { useFetchSectionFourData } from './useFetchSectionFourData.js'
 

--- a/src/components/annual-report/section4/SectionFour.js
+++ b/src/components/annual-report/section4/SectionFour.js
@@ -70,8 +70,8 @@ const Section4B = ({ title, subtitle, subsectionData }) => (
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((dataRow, index) => {
                 return (
-                    <>
-                        <table key={dataRow.name}>
+                    <React.Fragment key={dataRow.name}>
+                        <table>
                             <thead>
                                 <tr>
                                     <th>{dataRow.name}</th>
@@ -122,7 +122,7 @@ const Section4B = ({ title, subtitle, subsectionData }) => (
                             chartId={`chart${index}`}
                             chartInfo={dataRow.chartInfo}
                         />
-                    </>
+                    </React.Fragment>
                 )
             })}
     </>

--- a/src/components/annual-report/section4/SectionFour.js
+++ b/src/components/annual-report/section4/SectionFour.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
+import { Chart } from '../../Chart.js'
 import { calculateSection4 } from './section4Calculations.js'
 import { useFetchSectionFourData } from './useFetchSectionFourData.js'
 
@@ -67,46 +68,63 @@ const Section4B = ({ title, subtitle, subsectionData }) => (
         </table>
         {subsectionData
             .sort((a, b) => a.name.localeCompare(b.name))
-            .map((dataRow) => (
-                <table key={dataRow.name}>
-                    <thead>
-                        <tr>
-                            <th>{dataRow.name}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>Denominator A</td>
-                            <td>{dataRow.A}</td>
-                        </tr>
-                        <tr>
-                            <td>Denominator B</td>
-                            <td>{dataRow.B}</td>
-                        </tr>
-                        <tr>
-                            <td>Quality threshold</td>
-                            <td>±{dataRow.qualityThreshold}%</td>
-                        </tr>
-                        <tr>
-                            <td>Overall score</td>
-                            <td>{dataRow.overallScore}%</td>
-                        </tr>
-                        <tr>
-                            <td># Region with poor score</td>
-                            <td>{dataRow.divergentSubOrgUnits?.number}</td>
-                        </tr>
-                        <tr>
-                            <td>% Region with poor score</td>
-                            <td>{dataRow.divergentSubOrgUnits?.percentage}%</td>
-                        </tr>
-                        <tr>
-                            <td colSpan="2">
-                                {dataRow.divergentSubOrgUnits?.names}
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            ))}
+            .map((dataRow, index) => {
+                return (
+                    <>
+                        <table key={dataRow.name}>
+                            <thead>
+                                <tr>
+                                    <th>{dataRow.name}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Denominator A</td>
+                                    <td>{dataRow.A}</td>
+                                </tr>
+                                <tr>
+                                    <td>Denominator B</td>
+                                    <td>{dataRow.B}</td>
+                                </tr>
+                                <tr>
+                                    <td>Quality threshold</td>
+                                    <td>±{dataRow.qualityThreshold}%</td>
+                                </tr>
+                                <tr>
+                                    <td>Overall score</td>
+                                    <td>{dataRow.overallScore}%</td>
+                                </tr>
+                                <tr>
+                                    <td># Region with poor score</td>
+                                    <td>
+                                        {dataRow.divergentSubOrgUnits?.number}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>% Region with poor score</td>
+                                    <td>
+                                        {
+                                            dataRow.divergentSubOrgUnits
+                                                ?.percentage
+                                        }
+                                        %
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colSpan="2">
+                                        {dataRow.divergentSubOrgUnits?.names}
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <Chart
+                            sectionId={'section4'}
+                            chartId={`chart${index}`}
+                            chartInfo={dataRow.chartInfo}
+                        />
+                    </>
+                )
+            })}
     </>
 )
 

--- a/src/components/annual-report/section4/section4ChartGenerator.js
+++ b/src/components/annual-report/section4/section4ChartGenerator.js
@@ -1,3 +1,5 @@
+import i18n from '@dhis2/d2-i18n'
+
 export const generateSection4Chart = (canvasId, chartInfo) => {
     const dataPoints = chartInfo.values
         .filter(({ invalid }) => !invalid)
@@ -24,7 +26,7 @@ export const generateSection4Chart = (canvasId, chartInfo) => {
         },
         series: [
             {
-                name: 'Orgunits',
+                name: i18n.t('Orgunits'),
                 data: dataPoints,
                 color: 'rgb(31,119,180)',
             },
@@ -83,7 +85,16 @@ export const generateSection4Chart = (canvasId, chartInfo) => {
         tooltip: {
             headerFormat: '',
             pointFormatter: function () {
-                return `<b>${this.custom.name}</b><br />${this.custom.yLabel}: ${this.y}<br/>${this.custom.xLabel}: ${this.x}`
+                return i18n.t(
+                    '<b>{{name}}</b><br/>{{yLabel}}: {{y}}<br/>{{xLabel}}: {{x}}',
+                    {
+                        name: this.custom.name,
+                        yLabel: this.custom.yLabel,
+                        y: this.y,
+                        xLabel: this.custom.xLabel,
+                        x: this.x,
+                    }
+                )
             },
         },
     }

--- a/src/components/annual-report/section4/section4ChartGenerator.js
+++ b/src/components/annual-report/section4/section4ChartGenerator.js
@@ -31,7 +31,7 @@ export const generateSection4Chart = (canvasId, chartInfo) => {
             {
                 type: 'line',
                 name: 'A = B',
-                data: [0, { x: xMax, y: xMax }],
+                data: dataPoints.length ? [0, { x: xMax, y: xMax }] : [],
                 color: 'black',
                 marker: { enabled: false },
                 enableMouseTracking: false,
@@ -39,7 +39,9 @@ export const generateSection4Chart = (canvasId, chartInfo) => {
             {
                 type: 'line',
                 name: `+ ${chartInfo.threshold}%`,
-                data: [0, { x: xMax, y: xMax + xMaxThreshold }],
+                data: dataPoints.length
+                    ? [0, { x: xMax, y: xMax + xMaxThreshold }]
+                    : [],
                 color: 'rgb(176,176,176)',
                 marker: { enabled: false },
                 enableMouseTracking: false,
@@ -47,7 +49,9 @@ export const generateSection4Chart = (canvasId, chartInfo) => {
             {
                 type: 'line',
                 name: `- ${chartInfo.threshold}%`,
-                data: [0, { x: xMax, y: xMax - xMaxThreshold }],
+                data: dataPoints.length
+                    ? [0, { x: xMax, y: xMax - xMaxThreshold }]
+                    : [],
                 color: 'rgb(176,176,176)',
                 marker: { enabled: false },
                 enableMouseTracking: false,

--- a/src/components/annual-report/section4/section4ChartGenerator.js
+++ b/src/components/annual-report/section4/section4ChartGenerator.js
@@ -1,0 +1,86 @@
+export const generateSection4Chart = (canvasId, chartInfo) => {
+    const dataPoints = chartInfo.values
+        .filter(({ invalid }) => !invalid)
+        .map(({ x, y, divergent, name }) => ({
+            x,
+            y,
+            marker: {
+                symbol: divergent ? 'diamond' : 'circle',
+            },
+            custom: {
+                name,
+                xLabel: chartInfo.x,
+                yLabel: chartInfo.y,
+            },
+        }))
+
+    const xMax = Math.max(...dataPoints.flatMap(({ x }) => x))
+    const xMaxThreshold = (xMax / 100) * chartInfo.threshold
+
+    return {
+        chart: {
+            renderTo: canvasId,
+            type: 'scatter',
+        },
+        series: [
+            {
+                name: 'Orgunits',
+                data: dataPoints,
+                color: 'rgb(31,119,180)',
+            },
+            {
+                type: 'line',
+                name: 'A = B',
+                data: [0, { x: xMax, y: xMax }],
+                color: 'black',
+                marker: { enabled: false },
+                enableMouseTracking: false,
+            },
+            {
+                type: 'line',
+                name: `+ ${chartInfo.threshold}%`,
+                data: [0, { x: xMax, y: xMax + xMaxThreshold }],
+                color: 'rgb(176,176,176)',
+                marker: { enabled: false },
+                enableMouseTracking: false,
+            },
+            {
+                type: 'line',
+                name: `- ${chartInfo.threshold}%`,
+                data: [0, { x: xMax, y: xMax - xMaxThreshold }],
+                color: 'rgb(176,176,176)',
+                marker: { enabled: false },
+                enableMouseTracking: false,
+            },
+        ],
+        xAxis: [
+            {
+                min: 0,
+                title: {
+                    text: chartInfo.x,
+                },
+            },
+        ],
+        yAxis: [
+            {
+                min: 0,
+                title: {
+                    text: chartInfo.y,
+                },
+            },
+        ],
+        plotOptions: {
+            series: {
+                marker: {
+                    symbol: 'circle',
+                },
+            },
+        },
+        tooltip: {
+            headerFormat: '',
+            pointFormatter: function () {
+                return `<b>${this.custom.name}</b><br />${this.custom.yLabel}: ${this.y}<br/>${this.custom.xLabel}: ${this.x}`
+            },
+        },
+    }
+}

--- a/src/components/annual-report/section4/section4ChartGenerator.js
+++ b/src/components/annual-report/section4/section4ChartGenerator.js
@@ -26,7 +26,7 @@ export const generateSection4Chart = (canvasId, chartInfo) => {
         },
         series: [
             {
-                name: i18n.t('Orgunits'),
+                name: i18n.t('Org units'),
                 data: dataPoints,
                 color: 'rgb(31,119,180)',
             },


### PR DESCRIPTION
This PR (for ticket https://dhis2.atlassian.net/browse/RWDQA-14)

- implements functions for generating charts (scatter with target lines) needed in Section 4
- handle empty `chartInfo.values` case: chart with "No data to display" text is shown

Chart screenshots:
Scatter chart with target lines and outliers using diamond markers:
<img width="1040" alt="Screenshot 2023-11-01 at 15 24 56" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/c9bc323c-9adc-4f07-ba5f-622038f40e95">

Same chart with tooltip:
<img width="1032" alt="Screenshot 2023-11-01 at 15 25 27" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/bf15b62f-c3e7-4809-8bd9-8330bf957522">


