### PR TITLE
feat: add section1 chartInfo [RWDQA-56]

### DIFF
--- a/src/components/annual-report/section1/SectionOne.js
+++ b/src/components/annual-report/section1/SectionOne.js
@@ -130,6 +130,8 @@ export const SectionOne = ({ reportParameters }) => {
             reportQueryResponse: data,
             mappedConfigurations: reportParameters.mappedConfiguration,
             period: reportParameters.periods[0].id,
+            periodsIDs: reportParameters.periods.map((p) => p.id),
+            overallOrgUnit: reportParameters.orgUnits[0],
         })
 
         return (

--- a/src/components/annual-report/section1/section1Calculations.js
+++ b/src/components/annual-report/section1/section1Calculations.js
@@ -656,12 +656,13 @@ const getSection1dChartInfo = ({ allOrgUnitsData, periodsIDs, ou }) => {
     })
 
     for (const dx in formattedData) {
-        const points = periods.map((pe) =>
-            getVal({ response: formattedData, dx, ou, pe })
+        const points = periods.map(
+            (pe) =>
+                getVal({ response: formattedData, dx: 'wrong', ou, pe }) ?? null
         )
 
-        // if all points are undefined: skip; otherwise, add
-        if (points.some((val) => val !== undefined)) {
+        // if all points are null: skip; otherwise, add
+        if (points.some((val) => val !== null)) {
             chartInfo.values.push({
                 name: allOrgUnitsData.metaData?.items?.[dx]?.name ?? '',
                 points,

--- a/src/components/annual-report/section1/section1Calculations.js
+++ b/src/components/annual-report/section1/section1Calculations.js
@@ -657,8 +657,7 @@ const getSection1dChartInfo = ({ allOrgUnitsData, periodsIDs, ou }) => {
 
     for (const dx in formattedData) {
         const points = periods.map(
-            (pe) =>
-                getVal({ response: formattedData, dx: 'wrong', ou, pe }) ?? null
+            (pe) => getVal({ response: formattedData, dx, ou, pe }) ?? null
         )
 
         // if all points are null: skip; otherwise, add


### PR DESCRIPTION
This PR adds the chartInfo as discussed on https://dhis2.atlassian.net/browse/RWDQA-56

Note that since there is one chart for the entire section (specifically the chart is for Section 1D), I have just put the `chartInfo` at  the same level as the data for each section. I can move this if desired.

```
{
   "section1a": [],
   "section1b": [],
   "section1c": [],
   "section1d": [],
   "chartInfo": {},
}
```