### PR TITLE
fix: optimize numerator relations [RWDQA-18]

### DIFF
--- a/src/components/config-tabs/ConfigTabs.js
+++ b/src/components/config-tabs/ConfigTabs.js
@@ -2,12 +2,12 @@ import { CircularLoader } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import styles from './ConfigTabs.module.css'
+import { NumeratorRelations } from './numerator-relations/index.js'
 import { DenominatorRelations } from './tab-contents/DenominatorRelations.js'
 import { Denominators } from './tab-contents/Denominators.js'
 import { ExternalDataComparison } from './tab-contents/ExternalDataComparison.js'
 import { NumeratorGroups } from './tab-contents/NumeratorGroups.js'
 import { NumeratorParameters } from './tab-contents/NumeratorParameters.js'
-import { NumeratorRelations } from './tab-contents/NumeratorRelations.js'
 import { Numerators } from './tab-contents/Numerators.js'
 
 function Tabs({ loading, configurations, mappedNumerators }) {

--- a/src/components/config-tabs/ConfigTabs.module.css
+++ b/src/components/config-tabs/ConfigTabs.module.css
@@ -1,81 +1,75 @@
 .container {
-  /* background: #f1f1f1; */
-  margin: 20px auto;
-  word-break: break-all;
-
+    margin: 20px auto;
 }
 
 .blocTabs {
-  display: flex;
+    display: flex;
 }
 .tabs {
-  padding: 10px 0;
-  text-align: center;
-  flex-grow: 1;
-  background: rgba(128, 128, 128, 0.075);
-  cursor: pointer;
-  border-bottom: 1px solid rgba(22, 132, 33, 0.274);
-  box-sizing: content-box;
-  position: relative;
-  outline: none;
-  border-radius: 2px;
+    padding: 10px 0;
+    text-align: center;
+    flex-grow: 1;
+    background: rgba(128, 128, 128, 0.075);
+    cursor: pointer;
+    border-bottom: 1px solid rgba(22, 132, 33, 0.274);
+    box-sizing: content-box;
+    position: relative;
+    outline: none;
+    border-radius: 2px;
 }
-.tabs:not(:last-child){
-  border-right: 1px solid rgba(0, 0, 0, 0.274);
+.tabs:not(:last-child) {
+    border-right: 1px solid rgba(0, 0, 0, 0.274);
 }
 
-.activeTabs  {
-  flex-grow: 1;
-  background: white;
-  border-bottom: 1px solid transparent;
+.activeTabs {
+    flex-grow: 1;
+    background: white;
+    border-bottom: 1px solid transparent;
 }
 
 .activeTabs::before {
-  content: "";
-  display: block;
-  position: absolute;
-  top: -5px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: calc(100% + 2px);
-  height: 5px;
-  background: rgb(88, 147, 241);
+    content: '';
+    display: block;
+    position: absolute;
+    top: -5px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% + 2px);
+    height: 5px;
+    background: rgb(88, 147, 241);
 }
-
-
 
 button {
-  border: none;
-  
+    border: none;
 }
 .contentTabs {
-  flex-grow : 1;
+    flex-grow: 1;
 }
 .content {
-  background: white;
-  padding: 20px;
-  width: 100%;
-  height: 100%;
-  display: none;
+    background: white;
+    padding: 20px;
+    width: 100%;
+    height: 100%;
+    display: none;
 }
 .content h2 {
-  padding: 0px 0 5px 0px;
+    padding: 0px 0 5px 0px;
 }
 .content hr {
-  width: 100px;
-  height: 2px;
-  background: #222;
-  margin-bottom: 5px;
-  margin-left: 0;
+    width: 100px;
+    height: 2px;
+    background: #222;
+    margin-bottom: 5px;
+    margin-left: 0;
 }
 .content p {
-  width: 100%;
-  height: 100%;
+    width: 100%;
+    height: 100%;
 }
 .activeContent {
-  display: block;
+    display: block;
 }
 
 .groupsContainer {
-  width: 100%;
+    width: 100%;
 }

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -8,22 +8,29 @@ import {
     ModalActions,
     ModalContent,
     ModalTitle,
-    SingleSelect,
-    SingleSelectOption,
     ButtonStrip,
-    Input,
+    InputFieldFF,
+    SingleSelectFieldFF,
+    ReactFinalForm,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React from 'react'
 import relationTypes from '../../../data/relationTypes.json'
 
+const { Form, Field } = ReactFinalForm
+
 const DEFAULT_FORM_VALUES = {
-    name: '',
+    name: undefined,
     type: undefined,
     A: undefined,
     B: undefined,
     criteria: 0,
 }
+
+const RELATION_TYPE_OPTIONS = relationTypes.map((type) => ({
+    label: type.displayName,
+    value: type.code,
+}))
 
 /**
  * If `numeratorRelationToEdit`, is provided, this will behave in "update" mode:
@@ -40,153 +47,112 @@ export function EditNumeratorRelationModal({
     configurations,
     onClose,
 }) {
-    // A, B, code, criteria, name, type
-    const [formState, setFormState] = useState(
-        numeratorRelationToEdit || DEFAULT_FORM_VALUES
-    )
-
-    const numeratorsWithDataIds = React.useMemo(
-        () =>
-            configurations.numerators.filter(
-                (numerator) => numerator.dataID != null
-            ),
-        [configurations.numerators]
-    )
+    const numeratorOptions = React.useMemo(() => {
+        const numeratorsWithDataIds = configurations.numerators.filter(
+            (numerator) => numerator.dataID != null
+        )
+        return numeratorsWithDataIds.map(({ name, code }) => ({
+            label: name,
+            value: code,
+        }))
+    }, [configurations.numerators])
 
     return (
-        <Modal onClose={onClose} position="middle">
-            <ModalTitle>Numerator relation</ModalTitle>
-            <ModalContent>
-                <Table>
-                    <TableBody>
-                        <TableRow>
-                            <TableCell>Name</TableCell>
-                            <TableCell>
-                                <Input
-                                    name="name"
-                                    required
-                                    value={formState.name}
-                                    onChange={(e) =>
-                                        setFormState({
-                                            ...formState,
-                                            name: e.value,
-                                        })
-                                    }
-                                />
-                            </TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell>Type</TableCell>
-                            <TableCell>
-                                <SingleSelect
-                                    name="type"
-                                    placeholder="Select relation type"
-                                    selected={formState.type}
-                                    onChange={(e) =>
-                                        setFormState({
-                                            ...formState,
-                                            type: e.selected,
-                                        })
-                                    }
-                                >
-                                    {relationTypes.map((type) => (
-                                        <SingleSelectOption
-                                            label={type.displayName}
-                                            value={type.code}
-                                            key={type.code}
+        <Form
+            onSubmit={(...submitProps) => {
+                alert('todo')
+                console.log({ submitProps })
+            }}
+            initialValues={numeratorRelationToEdit || DEFAULT_FORM_VALUES}
+            // not subcribing to `values` prevents rerendering the entire form on every input change
+            subscription={{ submitting: true }}
+        >
+            {({ handleSubmit }) => (
+                <Modal onClose={onClose} position="middle">
+                    <ModalTitle>Numerator relation</ModalTitle>
+                    <ModalContent>
+                        <Table>
+                            <TableBody>
+                                <TableRow>
+                                    <TableCell>Name</TableCell>
+                                    <TableCell>
+                                        <Field
+                                            name="name"
+                                            component={InputFieldFF}
                                         />
-                                    ))}
-                                </SingleSelect>
-                            </TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell>Numerator A</TableCell>
-                            <TableCell>
-                                <SingleSelect
-                                    name="A"
-                                    placeholder="Select numerator A"
-                                    selected={formState.A}
-                                    onChange={(e) =>
-                                        setFormState({
-                                            ...formState,
-                                            A: e.selected,
-                                        })
-                                    }
-                                >
-                                    {numeratorsWithDataIds.map((numerator) => (
-                                        <SingleSelectOption
-                                            label={numerator.name}
-                                            value={numerator.code}
-                                            key={numerator.code}
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>Type</TableCell>
+                                    <TableCell>
+                                        <Field
+                                            name="type"
+                                            component={SingleSelectFieldFF}
+                                            options={RELATION_TYPE_OPTIONS}
+                                            placeholder="Select relation type"
                                         />
-                                    ))}
-                                </SingleSelect>
-                            </TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell>Numerator B</TableCell>
-                            <TableCell>
-                                <SingleSelect
-                                    name="B"
-                                    placeholder="Select numerator B"
-                                    selected={formState.B}
-                                    onChange={(e) =>
-                                        setFormState({
-                                            ...formState,
-                                            B: e.selected,
-                                        })
-                                    }
-                                >
-                                    {numeratorsWithDataIds.map((numerator) => (
-                                        <SingleSelectOption
-                                            label={numerator.name}
-                                            value={numerator.code}
-                                            key={numerator.code}
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>Numerator A</TableCell>
+                                    <TableCell>
+                                        <Field
+                                            name="A"
+                                            component={SingleSelectFieldFF}
+                                            options={numeratorOptions}
+                                            placeholder="Select numerator A"
                                         />
-                                    ))}
-                                </SingleSelect>
-                            </TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell>Threshold (+/-) %</TableCell>
-                            <TableCell>
-                                <Input
-                                    name="criteria"
-                                    type="number"
-                                    required
-                                    value={String(formState.criteria)}
-                                    onChange={(e) =>
-                                        setFormState({
-                                            ...formState,
-                                            criteria: Number(e.value),
-                                        })
-                                    }
-                                />
-                            </TableCell>
-                        </TableRow>
-                    </TableBody>
-                </Table>
-                <p>
-                    Threshold denotes the % difference from national figure that
-                    is accepted for a sub-national unit.
-                </p>
-            </ModalContent>
-            <ModalActions>
-                <ButtonStrip end>
-                    <Button secondary onClick={onClose}>
-                        Cancel
-                    </Button>
-                    <Button
-                        primary
-                        onClick={() => {
-                            alert('todo: add/update numerator relation')
-                        }}
-                    >
-                        Save
-                    </Button>
-                </ButtonStrip>
-            </ModalActions>
-        </Modal>
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>Numerator B</TableCell>
+                                    <TableCell>
+                                        <Field
+                                            name="B"
+                                            component={SingleSelectFieldFF}
+                                            options={numeratorOptions}
+                                            placeholder="Select numerator B"
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell>Threshold (+/-) %</TableCell>
+                                    <TableCell>
+                                        <Field
+                                            name="criteria"
+                                            component={InputFieldFF}
+                                            subscription={{ value: true }}
+                                            parse={(value) => Number(value)}
+                                            format={(value) => String(value)}
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                            </TableBody>
+                        </Table>
+                        <p>
+                            Threshold denotes the % difference from national
+                            figure that is accepted for a sub-national unit.
+                        </p>
+                    </ModalContent>
+                    <ModalActions>
+                        <ButtonStrip end>
+                            <Button secondary onClick={onClose}>
+                                Cancel
+                            </Button>
+                            <Button
+                                primary
+                                type="submit"
+                                onClick={() => {
+                                    handleSubmit()
+                                }}
+                            >
+                                Save
+                            </Button>
+                        </ButtonStrip>
+                    </ModalActions>
+                </Modal>
+            )}
+        </Form>
     )
 }
 EditNumeratorRelationModal.propTypes = {

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -26,8 +26,12 @@ export function EditNumeratorRelationModal({
         useState(previousRelation)
     // A, B, code, criteria, name, type
 
-    const numeratorsWithDataIds = configurations.numerators.filter(
-        (numerator) => numerator.dataID != null
+    const numeratorsWithDataIds = React.useMemo(
+        () =>
+            configurations.numerators.filter(
+                (numerator) => numerator.dataID != null
+            ),
+        [configurations.numerators]
     )
 
     return (
@@ -51,7 +55,7 @@ export function EditNumeratorRelationModal({
                                             name: e.value,
                                         })
                                     }
-                                    requiredrequired
+                                    required
                                     className="input"
                                 />
                             </TableCell>
@@ -72,15 +76,13 @@ export function EditNumeratorRelationModal({
                                     placeholder="Select relation type"
                                     selected={newNumeratorRelationInfo.type}
                                 >
-                                    {relationTypes
-                                        ? relationTypes.map((type, key) => (
-                                              <SingleSelectOption
-                                                  label={type.displayName}
-                                                  value={type.code}
-                                                  key={key}
-                                              />
-                                          ))
-                                        : ''}
+                                    {relationTypes.map((type, key) => (
+                                        <SingleSelectOption
+                                            label={type.displayName}
+                                            value={type.code}
+                                            key={key}
+                                        />
+                                    ))}
                                 </SingleSelect>
                             </TableCell>
                         </TableRow>
@@ -130,17 +132,15 @@ export function EditNumeratorRelationModal({
                                     placeholder="Select numerator B"
                                     selected={newNumeratorRelationInfo.B}
                                 >
-                                    {numeratorsWithDataIds
-                                        ? numeratorsWithDataIds.map(
-                                              (numerator, key) => (
-                                                  <SingleSelectOption
-                                                      label={numerator.name}
-                                                      value={numerator.code}
-                                                      key={key}
-                                                  />
-                                              )
-                                          )
-                                        : ''}
+                                    {numeratorsWithDataIds.map(
+                                        (numerator, key) => (
+                                            <SingleSelectOption
+                                                label={numerator.name}
+                                                value={numerator.code}
+                                                key={key}
+                                            />
+                                        )
+                                    )}
                                 </SingleSelect>
                             </TableCell>
                         </TableRow>

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -17,14 +17,33 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import relationTypes from '../../../data/relationTypes.json'
 
+const DEFAULT_FORM_VALUES = {
+    name: '',
+    type: undefined,
+    A: undefined,
+    B: undefined,
+    criteria: 0,
+}
+
+/**
+ * If `numeratorRelationToEdit`, is provided, this will behave in "update" mode:
+ * - the fields will be prefilled with the values of that relation
+ * - the data store mutation will be an "update" action on that relation, (todo)
+ * - some text in the modal will refer to editing/updating
+ * Otherwise, this will behave in "add new" mode:
+ * - the fields will be empty (todo)
+ * - the data store mutation will create a new numeratorRelation object (todo)
+ * - text in the modal will refer to creating/adding new (todo)
+ */
 export function EditNumeratorRelationModal({
-    previousRelation,
+    numeratorRelationToEdit,
     configurations,
     onClose,
 }) {
-    const [newNumeratorRelationInfo, setNewNumeratorRelationInfo] =
-        useState(previousRelation)
     // A, B, code, criteria, name, type
+    const [formState, setFormState] = useState(
+        numeratorRelationToEdit || DEFAULT_FORM_VALUES
+    )
 
     const numeratorsWithDataIds = React.useMemo(
         () =>
@@ -46,10 +65,10 @@ export function EditNumeratorRelationModal({
                                 <Input
                                     name="name"
                                     required
-                                    value={newNumeratorRelationInfo.name}
+                                    value={formState.name}
                                     onChange={(e) =>
-                                        setNewNumeratorRelationInfo({
-                                            ...newNumeratorRelationInfo,
+                                        setFormState({
+                                            ...formState,
                                             name: e.value,
                                         })
                                     }
@@ -62,19 +81,19 @@ export function EditNumeratorRelationModal({
                                 <SingleSelect
                                     name="type"
                                     placeholder="Select relation type"
-                                    selected={newNumeratorRelationInfo.type}
+                                    selected={formState.type}
                                     onChange={(e) =>
-                                        setNewNumeratorRelationInfo({
-                                            ...newNumeratorRelationInfo,
+                                        setFormState({
+                                            ...formState,
                                             type: e.selected,
                                         })
                                     }
                                 >
-                                    {relationTypes.map((type, key) => (
+                                    {relationTypes.map((type) => (
                                         <SingleSelectOption
                                             label={type.displayName}
                                             value={type.code}
-                                            key={key}
+                                            key={type.code}
                                         />
                                     ))}
                                 </SingleSelect>
@@ -86,23 +105,21 @@ export function EditNumeratorRelationModal({
                                 <SingleSelect
                                     name="A"
                                     placeholder="Select numerator A"
-                                    selected={newNumeratorRelationInfo.A}
+                                    selected={formState.A}
                                     onChange={(e) =>
-                                        setNewNumeratorRelationInfo({
-                                            ...newNumeratorRelationInfo,
+                                        setFormState({
+                                            ...formState,
                                             A: e.selected,
                                         })
                                     }
                                 >
-                                    {numeratorsWithDataIds.map(
-                                        (numerator, key) => (
-                                            <SingleSelectOption
-                                                label={numerator.name}
-                                                value={numerator.code}
-                                                key={key}
-                                            />
-                                        )
-                                    )}
+                                    {numeratorsWithDataIds.map((numerator) => (
+                                        <SingleSelectOption
+                                            label={numerator.name}
+                                            value={numerator.code}
+                                            key={numerator.code}
+                                        />
+                                    ))}
                                 </SingleSelect>
                             </TableCell>
                         </TableRow>
@@ -112,23 +129,21 @@ export function EditNumeratorRelationModal({
                                 <SingleSelect
                                     name="B"
                                     placeholder="Select numerator B"
-                                    selected={newNumeratorRelationInfo.B}
+                                    selected={formState.B}
                                     onChange={(e) =>
-                                        setNewNumeratorRelationInfo({
-                                            ...newNumeratorRelationInfo,
+                                        setFormState({
+                                            ...formState,
                                             B: e.selected,
                                         })
                                     }
                                 >
-                                    {numeratorsWithDataIds.map(
-                                        (numerator, key) => (
-                                            <SingleSelectOption
-                                                label={numerator.name}
-                                                value={numerator.code}
-                                                key={key}
-                                            />
-                                        )
-                                    )}
+                                    {numeratorsWithDataIds.map((numerator) => (
+                                        <SingleSelectOption
+                                            label={numerator.name}
+                                            value={numerator.code}
+                                            key={numerator.code}
+                                        />
+                                    ))}
                                 </SingleSelect>
                             </TableCell>
                         </TableRow>
@@ -139,11 +154,11 @@ export function EditNumeratorRelationModal({
                                     name="criteria"
                                     type="number"
                                     required
-                                    value={newNumeratorRelationInfo.criteria}
+                                    value={String(formState.criteria)}
                                     onChange={(e) =>
-                                        setNewNumeratorRelationInfo({
-                                            ...newNumeratorRelationInfo,
-                                            criteria: e.value,
+                                        setFormState({
+                                            ...formState,
+                                            criteria: Number(e.value),
                                         })
                                     }
                                 />
@@ -176,6 +191,6 @@ export function EditNumeratorRelationModal({
 }
 EditNumeratorRelationModal.propTypes = {
     configurations: PropTypes.object,
-    previousRelation: PropTypes.object,
+    numeratorRelationToEdit: PropTypes.object,
     onClose: PropTypes.func,
 }

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -17,22 +17,21 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import relationTypes from '../../../data/relationTypes.json'
 
-export function EditNumeratorRelationModal({ configurations, hide, onClose }) {
-    const [newNumeratorRelationInfo, setNewNumeratorRelationInfo] = useState({
-        A: '',
-        B: '',
-        code: '',
-        criteria: 10,
-        name: '',
-        type: '',
-    })
+export function EditNumeratorRelationModal({
+    previousRelation,
+    configurations,
+    onClose,
+}) {
+    const [newNumeratorRelationInfo, setNewNumeratorRelationInfo] =
+        useState(previousRelation)
+    // A, B, code, criteria, name, type
 
     const numeratorsWithDataIds = configurations.numerators.filter(
         (numerator) => numerator.dataID != null
     )
 
     return (
-        <Modal onClose={onClose} hide={hide} position="middle">
+        <Modal onClose={onClose} position="middle">
             <ModalTitle>Numerator relation</ModalTitle>
             <ModalContent>
                 <Table>
@@ -180,9 +179,9 @@ export function EditNumeratorRelationModal({ configurations, hide, onClose }) {
                     </Button>
                     <Button
                         primary
-                        onClick={() =>
-                            console.log('creating numerator relations')
-                        }
+                        onClick={() => {
+                            alert('todo: add/update numerator relation')
+                        }}
                     >
                         Create
                     </Button>
@@ -193,6 +192,6 @@ export function EditNumeratorRelationModal({ configurations, hide, onClose }) {
 }
 EditNumeratorRelationModal.propTypes = {
     configurations: PropTypes.object,
-    hide: PropTypes.bool,
+    previousRelation: PropTypes.object,
     onClose: PropTypes.func,
 }

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -48,9 +48,10 @@ export function EditNumeratorRelationModal({
     onClose,
 }) {
     const numeratorOptions = React.useMemo(() => {
-        const numeratorsWithDataIds = configurations.numerators.filter(
-            (numerator) => numerator.dataID != null
-        )
+        const numeratorsWithDataIds = configurations.numerators
+            .filter((numerator) => numerator.dataID != null)
+            // sort is okay because filter() creates a copy
+            .toSorted((a, b) => a.name.localeCompare(b.name))
         return numeratorsWithDataIds.map(({ name, code }) => ({
             label: name,
             value: code,

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -41,13 +41,11 @@ export function EditNumeratorRelationModal({
                 <Table>
                     <TableBody>
                         <TableRow>
-                            <TableCell>
-                                <p>Name</p>
-                            </TableCell>
+                            <TableCell>Name</TableCell>
                             <TableCell>
                                 <Input
-                                    label="Name"
                                     name="name"
+                                    required
                                     value={newNumeratorRelationInfo.name}
                                     onChange={(e) =>
                                         setNewNumeratorRelationInfo({
@@ -55,26 +53,22 @@ export function EditNumeratorRelationModal({
                                             name: e.value,
                                         })
                                     }
-                                    required
-                                    className="input"
                                 />
                             </TableCell>
                         </TableRow>
                         <TableRow>
-                            <TableCell>
-                                <p>Type</p>
-                            </TableCell>
+                            <TableCell>Type</TableCell>
                             <TableCell>
                                 <SingleSelect
-                                    className="select"
+                                    name="type"
+                                    placeholder="Select relation type"
+                                    selected={newNumeratorRelationInfo.type}
                                     onChange={(e) =>
                                         setNewNumeratorRelationInfo({
                                             ...newNumeratorRelationInfo,
                                             type: e.selected,
                                         })
                                     }
-                                    placeholder="Select relation type"
-                                    selected={newNumeratorRelationInfo.type}
                                 >
                                     {relationTypes.map((type, key) => (
                                         <SingleSelectOption
@@ -87,50 +81,18 @@ export function EditNumeratorRelationModal({
                             </TableCell>
                         </TableRow>
                         <TableRow>
-                            <TableCell>
-                                <p>Numerator A</p>
-                            </TableCell>
+                            <TableCell>Numerator A</TableCell>
                             <TableCell>
                                 <SingleSelect
-                                    className="select"
+                                    name="A"
+                                    placeholder="Select numerator A"
+                                    selected={newNumeratorRelationInfo.A}
                                     onChange={(e) =>
                                         setNewNumeratorRelationInfo({
                                             ...newNumeratorRelationInfo,
                                             A: e.selected,
                                         })
                                     }
-                                    placeholder="Select numerator A"
-                                    selected={newNumeratorRelationInfo.A}
-                                >
-                                    {numeratorsWithDataIds
-                                        ? numeratorsWithDataIds.map(
-                                              (numerator, key) => (
-                                                  <SingleSelectOption
-                                                      label={numerator.name}
-                                                      value={numerator.code}
-                                                      key={key}
-                                                  />
-                                              )
-                                          )
-                                        : ''}
-                                </SingleSelect>
-                            </TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell>
-                                <p>Numerator B</p>
-                            </TableCell>
-                            <TableCell>
-                                <SingleSelect
-                                    className="select"
-                                    onChange={(e) =>
-                                        setNewNumeratorRelationInfo({
-                                            ...newNumeratorRelationInfo,
-                                            B: e.selected,
-                                        })
-                                    }
-                                    placeholder="Select numerator B"
-                                    selected={newNumeratorRelationInfo.B}
                                 >
                                     {numeratorsWithDataIds.map(
                                         (numerator, key) => (
@@ -145,16 +107,38 @@ export function EditNumeratorRelationModal({
                             </TableCell>
                         </TableRow>
                         <TableRow>
+                            <TableCell>Numerator B</TableCell>
                             <TableCell>
-                                <p>Threshold (+/-) %</p>
+                                <SingleSelect
+                                    name="B"
+                                    placeholder="Select numerator B"
+                                    selected={newNumeratorRelationInfo.B}
+                                    onChange={(e) =>
+                                        setNewNumeratorRelationInfo({
+                                            ...newNumeratorRelationInfo,
+                                            B: e.selected,
+                                        })
+                                    }
+                                >
+                                    {numeratorsWithDataIds.map(
+                                        (numerator, key) => (
+                                            <SingleSelectOption
+                                                label={numerator.name}
+                                                value={numerator.code}
+                                                key={key}
+                                            />
+                                        )
+                                    )}
+                                </SingleSelect>
                             </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell>Threshold (+/-) %</TableCell>
                             <TableCell>
                                 <Input
-                                    label="Name"
-                                    name="name"
-                                    required
-                                    className="input"
+                                    name="criteria"
                                     type="number"
+                                    required
                                     value={newNumeratorRelationInfo.criteria}
                                     onChange={(e) =>
                                         setNewNumeratorRelationInfo({
@@ -183,7 +167,7 @@ export function EditNumeratorRelationModal({
                             alert('todo: add/update numerator relation')
                         }}
                     >
-                        Create
+                        Save
                     </Button>
                 </ButtonStrip>
             </ModalActions>

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -1,0 +1,198 @@
+import {
+    Button,
+    Table,
+    TableBody,
+    TableCell,
+    TableRow,
+    Modal,
+    ModalActions,
+    ModalContent,
+    ModalTitle,
+    SingleSelect,
+    SingleSelectOption,
+    ButtonStrip,
+    Input,
+} from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+import relationTypes from '../../../data/relationTypes.json'
+
+export function EditNumeratorRelationModal({ configurations, hide, onClose }) {
+    const [newNumeratorRelationInfo, setNewNumeratorRelationInfo] = useState({
+        A: '',
+        B: '',
+        code: '',
+        criteria: 10,
+        name: '',
+        type: '',
+    })
+
+    const numeratorsWithDataIds = configurations.numerators.filter(
+        (numerator) => numerator.dataID != null
+    )
+
+    return (
+        <Modal onClose={onClose} hide={hide} position="middle">
+            <ModalTitle>Numerator relation</ModalTitle>
+            <ModalContent>
+                <Table>
+                    <TableBody>
+                        <TableRow>
+                            <TableCell>
+                                <p>Name</p>
+                            </TableCell>
+                            <TableCell>
+                                <Input
+                                    label="Name"
+                                    name="name"
+                                    value={newNumeratorRelationInfo.name}
+                                    onChange={(e) =>
+                                        setNewNumeratorRelationInfo({
+                                            ...newNumeratorRelationInfo,
+                                            name: e.value,
+                                        })
+                                    }
+                                    requiredrequired
+                                    className="input"
+                                />
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell>
+                                <p>Type</p>
+                            </TableCell>
+                            <TableCell>
+                                <SingleSelect
+                                    className="select"
+                                    onChange={(e) =>
+                                        setNewNumeratorRelationInfo({
+                                            ...newNumeratorRelationInfo,
+                                            type: e.selected,
+                                        })
+                                    }
+                                    placeholder="Select relation type"
+                                    selected={newNumeratorRelationInfo.type}
+                                >
+                                    {relationTypes
+                                        ? relationTypes.map((type, key) => (
+                                              <SingleSelectOption
+                                                  label={type.displayName}
+                                                  value={type.code}
+                                                  key={key}
+                                              />
+                                          ))
+                                        : ''}
+                                </SingleSelect>
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell>
+                                <p>Numerator A</p>
+                            </TableCell>
+                            <TableCell>
+                                <SingleSelect
+                                    className="select"
+                                    onChange={(e) =>
+                                        setNewNumeratorRelationInfo({
+                                            ...newNumeratorRelationInfo,
+                                            A: e.selected,
+                                        })
+                                    }
+                                    placeholder="Select numerator A"
+                                    selected={newNumeratorRelationInfo.A}
+                                >
+                                    {numeratorsWithDataIds
+                                        ? numeratorsWithDataIds.map(
+                                              (numerator, key) => (
+                                                  <SingleSelectOption
+                                                      label={numerator.name}
+                                                      value={numerator.code}
+                                                      key={key}
+                                                  />
+                                              )
+                                          )
+                                        : ''}
+                                </SingleSelect>
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell>
+                                <p>Numerator B</p>
+                            </TableCell>
+                            <TableCell>
+                                <SingleSelect
+                                    className="select"
+                                    onChange={(e) =>
+                                        setNewNumeratorRelationInfo({
+                                            ...newNumeratorRelationInfo,
+                                            B: e.selected,
+                                        })
+                                    }
+                                    placeholder="Select numerator B"
+                                    selected={newNumeratorRelationInfo.B}
+                                >
+                                    {numeratorsWithDataIds
+                                        ? numeratorsWithDataIds.map(
+                                              (numerator, key) => (
+                                                  <SingleSelectOption
+                                                      label={numerator.name}
+                                                      value={numerator.code}
+                                                      key={key}
+                                                  />
+                                              )
+                                          )
+                                        : ''}
+                                </SingleSelect>
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell>
+                                <p>Threshold (+/-) %</p>
+                            </TableCell>
+                            <TableCell>
+                                <Input
+                                    label="Name"
+                                    name="name"
+                                    required
+                                    className="input"
+                                    type="number"
+                                    value={newNumeratorRelationInfo.criteria}
+                                    onChange={(e) =>
+                                        setNewNumeratorRelationInfo({
+                                            ...newNumeratorRelationInfo,
+                                            criteria: e.value,
+                                        })
+                                    }
+                                />
+                            </TableCell>
+                        </TableRow>
+                    </TableBody>
+                </Table>
+                <p>
+                    Threshold denotes the % difference from national figure that
+                    is accepted for a sub-national unit.
+                </p>
+            </ModalContent>
+            <ModalActions>
+                <ButtonStrip end>
+                    <Button secondary onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        primary
+                        onClick={() =>
+                            console.log('creating numerator relations')
+                        }
+                    >
+                        Create
+                    </Button>
+                </ButtonStrip>
+            </ModalActions>
+        </Modal>
+    )
+}
+EditNumeratorRelationModal.propTypes = {
+    configurations: PropTypes.object,
+    hide: PropTypes.bool,
+    onClose: PropTypes.func,
+}

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -35,12 +35,12 @@ const RELATION_TYPE_OPTIONS = relationTypes.map((type) => ({
 /**
  * If `numeratorRelationToEdit`, is provided, this will behave in "update" mode:
  * - the fields will be prefilled with the values of that relation
- * - the data store mutation will be an "update" action on that relation, (todo)
  * - some text in the modal will refer to editing/updating
+ * - the data store mutation will be an "update" action on that relation (todo)
  * Otherwise, this will behave in "add new" mode:
  * - the fields will be empty
+ * - text in the modal will refer to creating/adding new
  * - the data store mutation will create a new numeratorRelation object (todo)
- * - text in the modal will refer to creating/adding new (todo)
  */
 export function EditNumeratorRelationModal({
     numeratorRelationToEdit,
@@ -69,7 +69,10 @@ export function EditNumeratorRelationModal({
         >
             {({ handleSubmit }) => (
                 <Modal onClose={onClose} position="middle">
-                    <ModalTitle>Configure numerator relation</ModalTitle>
+                    <ModalTitle>
+                        {numeratorRelationToEdit ? 'Edit ' : 'Create '}
+                        numerator relation
+                    </ModalTitle>
                     <ModalContent>
                         <Table>
                             <TableBody>
@@ -146,7 +149,7 @@ export function EditNumeratorRelationModal({
                                     handleSubmit()
                                 }}
                             >
-                                Save
+                                {numeratorRelationToEdit ? 'Save' : 'Create'}
                             </Button>
                         </ButtonStrip>
                     </ModalActions>

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -69,7 +69,7 @@ export function EditNumeratorRelationModal({
         >
             {({ handleSubmit }) => (
                 <Modal onClose={onClose} position="middle">
-                    <ModalTitle>Numerator relation</ModalTitle>
+                    <ModalTitle>Configure numerator relation</ModalTitle>
                     <ModalContent>
                         <Table>
                             <TableBody>

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -127,6 +127,7 @@ export function EditNumeratorRelationModal({
                                             subscription={{ value: true }}
                                             parse={(value) => Number(value)}
                                             format={(value) => String(value)}
+                                            type="number"
                                         />
                                     </TableCell>
                                 </TableRow>

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -38,7 +38,7 @@ const RELATION_TYPE_OPTIONS = relationTypes.map((type) => ({
  * - the data store mutation will be an "update" action on that relation, (todo)
  * - some text in the modal will refer to editing/updating
  * Otherwise, this will behave in "add new" mode:
- * - the fields will be empty (todo)
+ * - the fields will be empty
  * - the data store mutation will create a new numeratorRelation object (todo)
  * - text in the modal will refer to creating/adding new (todo)
  */

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -51,7 +51,7 @@ export function EditNumeratorRelationModal({
         const numeratorsWithDataIds = configurations.numerators
             .filter((numerator) => numerator.dataID != null)
             // sort is okay because filter() creates a copy
-            .toSorted((a, b) => a.name.localeCompare(b.name))
+            .sort((a, b) => a.name.localeCompare(b.name))
         return numeratorsWithDataIds.map(({ name, code }) => ({
             label: name,
             value: code,

--- a/src/components/config-tabs/numerator-relations/NumeratorRelationTableItem.js
+++ b/src/components/config-tabs/numerator-relations/NumeratorRelationTableItem.js
@@ -2,8 +2,7 @@ import {
     Button,
     TableCell,
     TableRow,
-    IconDelete16,
-    IconEdit16,
+    ButtonStrip,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState, useMemo } from 'react'
@@ -44,19 +43,21 @@ export function NumeratorRelationTableItem({
             <TableCell>{relationType.thresholdDescription}</TableCell>
             <TableCell>{relationType.description}</TableCell>
             <TableCell>
-                <Button
-                    icon={<IconEdit16 />}
-                    onClick={() => setEditModalOpen(true)}
-                >
-                    Edit
-                </Button>
-                <Button
-                    destructive
-                    icon={<IconDelete16 />}
-                    onClick={() => alert('todo: delete')}
-                >
-                    Delete
-                </Button>
+                <ButtonStrip>
+                    <Button
+                        small
+                        onClick={() => setEditModalOpen(true)}
+                    >
+                        Edit
+                    </Button>
+                    <Button
+                        small
+                        destructive
+                        onClick={() => alert('todo: delete')}
+                    >
+                        Delete
+                    </Button>
+                </ButtonStrip>
             </TableCell>
             {editModalOpen && (
                 <EditNumeratorRelationModal

--- a/src/components/config-tabs/numerator-relations/NumeratorRelationTableItem.js
+++ b/src/components/config-tabs/numerator-relations/NumeratorRelationTableItem.js
@@ -1,0 +1,64 @@
+import {
+    Button,
+    TableCell,
+    TableRow,
+    IconDelete16,
+    IconEdit16,
+} from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+import {
+    getNumeratorNameByCode,
+    getRelationType,
+} from '../../../utils/numeratorsMetadataData.js'
+
+export function NumeratorRelationTableItem({
+    configurations,
+    numeratorRelation: relation,
+}) {
+    // some of these values are hard to memoize effectively:
+    // they depend on the large configurations object
+    const numeratorAName = React.useMemo(
+        () => getNumeratorNameByCode(configurations.numerators, relation.A),
+        [configurations.numerators, relation.A]
+    )
+    const numeratorBName = React.useMemo(
+        () => getNumeratorNameByCode(configurations.numerators, relation.B),
+        [configurations.numerators, relation.B]
+    )
+    const relationType = React.useMemo(
+        () => getRelationType(relation.type),
+        [relation.type]
+    )
+
+    return (
+        <TableRow>
+            <TableCell>{relation.name}</TableCell>
+            <TableCell>{numeratorAName}</TableCell>
+            <TableCell>{numeratorBName}</TableCell>
+            <TableCell>{relationType.displayName}</TableCell>
+            <TableCell>{relation.criteria}</TableCell>
+            <TableCell>{relationType.thresholdDescription}</TableCell>
+            <TableCell>{relationType.description}</TableCell>
+            <TableCell>
+                <Button
+                    icon={<IconEdit16 />}
+                    onClick={() => alert('todo: edit')}
+                >
+                    Edit
+                </Button>
+                <Button
+                    destructive
+                    icon={<IconDelete16 />}
+                    onClick={() => alert('todo: delete')}
+                >
+                    Delete
+                </Button>
+            </TableCell>
+        </TableRow>
+    )
+}
+NumeratorRelationTableItem.propTypes = {
+    configurations: PropTypes.object,
+    numeratorRelation: PropTypes.object,
+}

--- a/src/components/config-tabs/numerator-relations/NumeratorRelationTableItem.js
+++ b/src/components/config-tabs/numerator-relations/NumeratorRelationTableItem.js
@@ -60,7 +60,7 @@ export function NumeratorRelationTableItem({
             </TableCell>
             {editModalOpen && (
                 <EditNumeratorRelationModal
-                    previousRelation={relation}
+                    numeratorRelationToEdit={relation}
                     configurations={configurations}
                     onClose={() => setEditModalOpen(false)}
                 />

--- a/src/components/config-tabs/numerator-relations/NumeratorRelationTableItem.js
+++ b/src/components/config-tabs/numerator-relations/NumeratorRelationTableItem.js
@@ -6,27 +6,30 @@ import {
     IconEdit16,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState, useMemo } from 'react'
 import {
     getNumeratorNameByCode,
     getRelationType,
 } from '../../../utils/numeratorsMetadataData.js'
+import { EditNumeratorRelationModal } from './EditNumeratorRelationModal.js'
 
 export function NumeratorRelationTableItem({
     configurations,
     numeratorRelation: relation,
 }) {
+    const [editModalOpen, setEditModalOpen] = useState(false)
+
     // some of these values are hard to memoize effectively:
     // they depend on the large configurations object
-    const numeratorAName = React.useMemo(
+    const numeratorAName = useMemo(
         () => getNumeratorNameByCode(configurations.numerators, relation.A),
         [configurations.numerators, relation.A]
     )
-    const numeratorBName = React.useMemo(
+    const numeratorBName = useMemo(
         () => getNumeratorNameByCode(configurations.numerators, relation.B),
         [configurations.numerators, relation.B]
     )
-    const relationType = React.useMemo(
+    const relationType = useMemo(
         () => getRelationType(relation.type),
         [relation.type]
     )
@@ -43,7 +46,7 @@ export function NumeratorRelationTableItem({
             <TableCell>
                 <Button
                     icon={<IconEdit16 />}
-                    onClick={() => alert('todo: edit')}
+                    onClick={() => setEditModalOpen(true)}
                 >
                     Edit
                 </Button>
@@ -55,6 +58,13 @@ export function NumeratorRelationTableItem({
                     Delete
                 </Button>
             </TableCell>
+            {editModalOpen && (
+                <EditNumeratorRelationModal
+                    previousRelation={relation}
+                    configurations={configurations}
+                    onClose={() => setEditModalOpen(false)}
+                />
+            )}
         </TableRow>
     )
 }

--- a/src/components/config-tabs/numerator-relations/NumeratorRelations.js
+++ b/src/components/config-tabs/numerator-relations/NumeratorRelations.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import relationTypes from '../../../data/relationTypes.json'
 import {
-    getNumeratorRelations,
+    getNumeratorNameByCode,
     getRelationType,
 } from '../../../utils/numeratorsMetadataData.js'
 
@@ -66,13 +66,13 @@ export const NumeratorRelations = ({ configurations }) => {
                             <TableRow key={key}>
                                 <TableCell>{relation.name}</TableCell>
                                 <TableCell>
-                                    {getNumeratorRelations(
+                                    {getNumeratorNameByCode(
                                         configurations.numerators,
                                         relation.A
                                     )}
                                 </TableCell>
                                 <TableCell>
-                                    {getNumeratorRelations(
+                                    {getNumeratorNameByCode(
                                         configurations.numerators,
                                         relation.B
                                     )}

--- a/src/components/config-tabs/numerator-relations/NumeratorRelations.js
+++ b/src/components/config-tabs/numerator-relations/NumeratorRelations.js
@@ -7,21 +7,14 @@ import {
     TableHead,
     TableRow,
     TableRowHead,
-    IconDelete16,
-    IconEdit16,
     IconAdd16,
+    ButtonStrip,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
-import {
-    getNumeratorNameByCode,
-    getRelationType,
-} from '../../../utils/numeratorsMetadataData.js'
-import { EditNumeratorRelationModal } from './EditNumeratorRelationModal.js'
+import React from 'react'
+import { NumeratorRelationTableItem } from './NumeratorRelationTableItem.js'
 
 export const NumeratorRelations = ({ configurations }) => {
-    const [isModalHidden, setIsModalHidden] = useState(true)
-
     const relations = configurations.numeratorRelations
 
     return (
@@ -43,57 +36,12 @@ export const NumeratorRelations = ({ configurations }) => {
                 </TableHead>
                 <TableBody>
                     {relations ? (
-                        relations.map((relation, key) => (
-                            <TableRow key={key}>
-                                <TableCell>{relation.name}</TableCell>
-                                <TableCell>
-                                    {getNumeratorNameByCode(
-                                        configurations.numerators,
-                                        relation.A
-                                    )}
-                                </TableCell>
-                                <TableCell>
-                                    {getNumeratorNameByCode(
-                                        configurations.numerators,
-                                        relation.B
-                                    )}
-                                </TableCell>
-                                <TableCell>
-                                    {getRelationType(relation.type).displayName}
-                                </TableCell>
-                                <TableCell>{relation.criteria}</TableCell>
-                                <TableCell>
-                                    {
-                                        getRelationType(relation.type)
-                                            .thresholdDescription
-                                    }
-                                </TableCell>
-                                <TableCell>
-                                    {getRelationType(relation.type).description}
-                                </TableCell>
-                                <TableCell>
-                                    <Button
-                                        name="Primary button"
-                                        onClick={() => setIsModalHidden(false)}
-                                        basic
-                                        button
-                                        value="default"
-                                        icon={<IconEdit16 />}
-                                    >
-                                        Edit
-                                    </Button>
-                                    <Button
-                                        name="Primary button"
-                                        onClick={() => console.log('It works!')}
-                                        destructive
-                                        button
-                                        value="default"
-                                        icon={<IconDelete16 />}
-                                    >
-                                        Delete
-                                    </Button>
-                                </TableCell>
-                            </TableRow>
+                        relations.map((relation) => (
+                            <NumeratorRelationTableItem
+                                numeratorRelation={relation}
+                                configurations={configurations}
+                                key={relation.code}
+                            />
                         ))
                     ) : (
                         <TableRow>
@@ -101,34 +49,20 @@ export const NumeratorRelations = ({ configurations }) => {
                         </TableRow>
                     )}
                     <TableRow>
-                        <TableCell></TableCell>
-                        <TableCell></TableCell>
-                        <TableCell></TableCell>
-                        <TableCell></TableCell>
-                        <TableCell></TableCell>
-                        <TableCell></TableCell>
-                        <TableCell></TableCell>
-                        <TableCell>
-                            <Button
-                                name="Primary button"
-                                onClick={() => setIsModalHidden(false)}
-                                primary
-                                button
-                                value="default"
-                                icon={<IconAdd16 />}
-                            >
-                                Add Numerator Relation
-                            </Button>
+                        <TableCell colSpan="8">
+                            <ButtonStrip end>
+                                <Button
+                                    primary
+                                    icon={<IconAdd16 />}
+                                    onClick={() => alert('todo')}
+                                >
+                                    Add Numerator Relation
+                                </Button>
+                            </ButtonStrip>
                         </TableCell>
                     </TableRow>
                 </TableBody>
             </Table>
-
-            <EditNumeratorRelationModal
-                onClose={() => setIsModalHidden(true)}
-                hide={isModalHidden}
-                configurations={configurations}
-            />
         </div>
     )
 }

--- a/src/components/config-tabs/numerator-relations/NumeratorRelations.js
+++ b/src/components/config-tabs/numerator-relations/NumeratorRelations.js
@@ -10,38 +10,19 @@ import {
     IconDelete16,
     IconEdit16,
     IconAdd16,
-    Modal,
-    ModalActions,
-    ModalContent,
-    ModalTitle,
-    SingleSelect,
-    SingleSelectOption,
-    ButtonStrip,
-    Input,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
-import relationTypes from '../../../data/relationTypes.json'
 import {
     getNumeratorNameByCode,
     getRelationType,
 } from '../../../utils/numeratorsMetadataData.js'
+import { EditNumeratorRelationModal } from './EditNumeratorRelationModal.js'
 
 export const NumeratorRelations = ({ configurations }) => {
     const [isModalHidden, setIsModalHidden] = useState(true)
-    const [newNumeratorRelationInfo, setNewNumeratorRelationInfo] = useState({
-        A: '',
-        B: '',
-        code: '',
-        criteria: 10,
-        name: '',
-        type: '',
-    })
 
     const relations = configurations.numeratorRelations
-    const numeratorsWithDataIds = configurations.numerators.filter(
-        (numerator) => numerator.dataID != null
-    )
 
     return (
         <div>
@@ -143,173 +124,11 @@ export const NumeratorRelations = ({ configurations }) => {
                 </TableBody>
             </Table>
 
-            {/* TODO: will move this modal in it's own component */}
-            <Modal
+            <EditNumeratorRelationModal
                 onClose={() => setIsModalHidden(true)}
                 hide={isModalHidden}
-                position="middle"
-            >
-                <ModalTitle>Numerator relation</ModalTitle>
-                <ModalContent>
-                    <Table>
-                        <TableBody>
-                            <TableRow>
-                                <TableCell>
-                                    <p>Name</p>
-                                </TableCell>
-                                <TableCell>
-                                    <Input
-                                        label="Name"
-                                        name="name"
-                                        value={newNumeratorRelationInfo.name}
-                                        onChange={(e) =>
-                                            setNewNumeratorRelationInfo({
-                                                ...newNumeratorRelationInfo,
-                                                name: e.value,
-                                            })
-                                        }
-                                        requiredrequired
-                                        className="input"
-                                    />
-                                </TableCell>
-                            </TableRow>
-                            <TableRow>
-                                <TableCell>
-                                    <p>Type</p>
-                                </TableCell>
-                                <TableCell>
-                                    <SingleSelect
-                                        className="select"
-                                        onChange={(e) =>
-                                            setNewNumeratorRelationInfo({
-                                                ...newNumeratorRelationInfo,
-                                                type: e.selected,
-                                            })
-                                        }
-                                        placeholder="Select relation type"
-                                        selected={newNumeratorRelationInfo.type}
-                                    >
-                                        {relationTypes
-                                            ? relationTypes.map((type, key) => (
-                                                  <SingleSelectOption
-                                                      label={type.displayName}
-                                                      value={type.code}
-                                                      key={key}
-                                                  />
-                                              ))
-                                            : ''}
-                                    </SingleSelect>
-                                </TableCell>
-                            </TableRow>
-                            <TableRow>
-                                <TableCell>
-                                    <p>Numerator A</p>
-                                </TableCell>
-                                <TableCell>
-                                    <SingleSelect
-                                        className="select"
-                                        onChange={(e) =>
-                                            setNewNumeratorRelationInfo({
-                                                ...newNumeratorRelationInfo,
-                                                A: e.selected,
-                                            })
-                                        }
-                                        placeholder="Select numerator A"
-                                        selected={newNumeratorRelationInfo.A}
-                                    >
-                                        {numeratorsWithDataIds
-                                            ? numeratorsWithDataIds.map(
-                                                  (numerator, key) => (
-                                                      <SingleSelectOption
-                                                          label={numerator.name}
-                                                          value={numerator.code}
-                                                          key={key}
-                                                      />
-                                                  )
-                                              )
-                                            : ''}
-                                    </SingleSelect>
-                                </TableCell>
-                            </TableRow>
-                            <TableRow>
-                                <TableCell>
-                                    <p>Numerator B</p>
-                                </TableCell>
-                                <TableCell>
-                                    <SingleSelect
-                                        className="select"
-                                        onChange={(e) =>
-                                            setNewNumeratorRelationInfo({
-                                                ...newNumeratorRelationInfo,
-                                                B: e.selected,
-                                            })
-                                        }
-                                        placeholder="Select numerator B"
-                                        selected={newNumeratorRelationInfo.B}
-                                    >
-                                        {numeratorsWithDataIds
-                                            ? numeratorsWithDataIds.map(
-                                                  (numerator, key) => (
-                                                      <SingleSelectOption
-                                                          label={numerator.name}
-                                                          value={numerator.code}
-                                                          key={key}
-                                                      />
-                                                  )
-                                              )
-                                            : ''}
-                                    </SingleSelect>
-                                </TableCell>
-                            </TableRow>
-                            <TableRow>
-                                <TableCell>
-                                    <p>Threshold (+/-) %</p>
-                                </TableCell>
-                                <TableCell>
-                                    <Input
-                                        label="Name"
-                                        name="name"
-                                        required
-                                        className="input"
-                                        type="number"
-                                        value={
-                                            newNumeratorRelationInfo.criteria
-                                        }
-                                        onChange={(e) =>
-                                            setNewNumeratorRelationInfo({
-                                                ...newNumeratorRelationInfo,
-                                                criteria: e.value,
-                                            })
-                                        }
-                                    />
-                                </TableCell>
-                            </TableRow>
-                        </TableBody>
-                    </Table>
-                    <p>
-                        Threshold denotes the % difference from national figure
-                        that is accepted for a sub-national unit.
-                    </p>
-                </ModalContent>
-                <ModalActions>
-                    <ButtonStrip end>
-                        <Button
-                            secondary
-                            onClick={() => setIsModalHidden(true)}
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            primary
-                            onClick={() =>
-                                console.log('creating numerator relations')
-                            }
-                        >
-                            Create
-                        </Button>
-                    </ButtonStrip>
-                </ModalActions>
-            </Modal>
+                configurations={configurations}
+            />
         </div>
     )
 }

--- a/src/components/config-tabs/numerator-relations/NumeratorRelations.js
+++ b/src/components/config-tabs/numerator-relations/NumeratorRelations.js
@@ -9,10 +9,41 @@ import {
     TableRowHead,
     IconAdd16,
     ButtonStrip,
+    TableFoot,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
+import { EditNumeratorRelationModal } from './EditNumeratorRelationModal.js'
 import { NumeratorRelationTableItem } from './NumeratorRelationTableItem.js'
+
+const NumeratorRelationTableFoot = ({ configurations }) => {
+    const [addNewModalOpen, setAddNewModalOpen] = useState(false)
+
+    return (
+        <TableFoot>
+            <TableRow>
+                <TableCell colSpan="8">
+                    <ButtonStrip end>
+                        <Button
+                            primary
+                            icon={<IconAdd16 />}
+                            onClick={() => setAddNewModalOpen(true)}
+                        >
+                            Add Numerator Relation
+                        </Button>
+                    </ButtonStrip>
+                </TableCell>
+            </TableRow>
+            {addNewModalOpen && (
+                <EditNumeratorRelationModal
+                    configurations={configurations}
+                    onClose={() => setAddNewModalOpen(false)}
+                />
+            )}
+        </TableFoot>
+    )
+}
+NumeratorRelationTableFoot.propTypes = { configurations: PropTypes.object }
 
 export const NumeratorRelations = ({ configurations }) => {
     const relations = configurations.numeratorRelations
@@ -48,20 +79,8 @@ export const NumeratorRelations = ({ configurations }) => {
                             <TableCell>No numerator relations found.</TableCell>
                         </TableRow>
                     )}
-                    <TableRow>
-                        <TableCell colSpan="8">
-                            <ButtonStrip end>
-                                <Button
-                                    primary
-                                    icon={<IconAdd16 />}
-                                    onClick={() => alert('todo')}
-                                >
-                                    Add Numerator Relation
-                                </Button>
-                            </ButtonStrip>
-                        </TableCell>
-                    </TableRow>
                 </TableBody>
+                <NumeratorRelationTableFoot configurations={configurations} />
             </Table>
         </div>
     )

--- a/src/components/config-tabs/numerator-relations/index.js
+++ b/src/components/config-tabs/numerator-relations/index.js
@@ -1,0 +1,1 @@
+export { NumeratorRelations } from './NumeratorRelations.js'

--- a/src/components/config-tabs/tab-contents/NumeratorRelations.js
+++ b/src/components/config-tabs/tab-contents/NumeratorRelations.js
@@ -27,13 +27,13 @@ import {
     getRelationType,
 } from '../../../utils/numeratorsMetadataData.js'
 
-export const NumeratorRelations = ({ toggleState, configurations }) => {
+export const NumeratorRelations = ({ configurations }) => {
     const [isModalHidden, setIsModalHidden] = useState(true)
     const [newNumeratorRelationInfo, setNewNumeratorRelationInfo] = useState({
         A: '',
         B: '',
         code: '',
-        criteria: 12,
+        criteria: 10,
         name: '',
         type: '',
     })
@@ -44,125 +44,104 @@ export const NumeratorRelations = ({ toggleState, configurations }) => {
     )
 
     return (
-        <div
-            className={
-                toggleState === 3 ? 'content  active-content' : 'content'
-            }
-        >
+        <div>
             <p>Numerator Relations</p>
             <hr />
-            <div className="relationsContainer">
-                <Table>
-                    <TableHead>
-                        <TableRowHead>
-                            <TableCellHead>Name</TableCellHead>
-                            <TableCellHead>Numerator A</TableCellHead>
-                            <TableCellHead>Numerator B</TableCellHead>
-                            <TableCellHead>Type</TableCellHead>
-                            <TableCellHead>Threshold (%)</TableCellHead>
-                            <TableCellHead>Threshold explanation</TableCellHead>
-                            <TableCellHead>Description</TableCellHead>
-                            <TableCellHead>Actions</TableCellHead>
-                        </TableRowHead>
-                    </TableHead>
-                    <TableBody>
-                        {relations ? (
-                            relations.map((relation, key) => (
-                                <TableRow key={key}>
-                                    <TableCell>{relation.name}</TableCell>
-                                    <TableCell>
-                                        {getNumeratorRelations(
-                                            configurations.numerators,
-                                            relation.A
-                                        )}
-                                    </TableCell>
-                                    <TableCell>
-                                        {getNumeratorRelations(
-                                            configurations.numerators,
-                                            relation.B
-                                        )}
-                                    </TableCell>
-                                    <TableCell>
-                                        {
-                                            getRelationType(relation.type)
-                                                .displayName
-                                        }
-                                    </TableCell>
-                                    <TableCell>{relation.criteria}</TableCell>
-                                    <TableCell>
-                                        {
-                                            getRelationType(relation.type)
-                                                .thresholdDescription
-                                        }
-                                    </TableCell>
-                                    <TableCell>
-                                        {
-                                            getRelationType(relation.type)
-                                                .description
-                                        }
-                                    </TableCell>
-                                    <TableCell>
-                                        <Button
-                                            name="Primary button"
-                                            onClick={() =>
-                                                setIsModalHidden(false)
-                                            }
-                                            basic
-                                            button
-                                            value="default"
-                                            icon={<IconEdit16 />}
-                                        >
-                                            {' '}
-                                            Edit
-                                        </Button>
-                                        <Button
-                                            name="Primary button"
-                                            onClick={() =>
-                                                console.log('It works!')
-                                            }
-                                            destructive
-                                            button
-                                            value="default"
-                                            icon={<IconDelete16 />}
-                                        >
-                                            {' '}
-                                            Delete
-                                        </Button>
-                                    </TableCell>
-                                </TableRow>
-                            ))
-                        ) : (
-                            <TableRow>
+            <Table>
+                <TableHead>
+                    <TableRowHead>
+                        <TableCellHead>Name</TableCellHead>
+                        <TableCellHead>Numerator A</TableCellHead>
+                        <TableCellHead>Numerator B</TableCellHead>
+                        <TableCellHead>Type</TableCellHead>
+                        <TableCellHead>Threshold (%)</TableCellHead>
+                        <TableCellHead>Threshold explanation</TableCellHead>
+                        <TableCellHead>Description</TableCellHead>
+                        <TableCellHead>Actions</TableCellHead>
+                    </TableRowHead>
+                </TableHead>
+                <TableBody>
+                    {relations ? (
+                        relations.map((relation, key) => (
+                            <TableRow key={key}>
+                                <TableCell>{relation.name}</TableCell>
                                 <TableCell>
-                                    No numerator relations found.
+                                    {getNumeratorRelations(
+                                        configurations.numerators,
+                                        relation.A
+                                    )}
+                                </TableCell>
+                                <TableCell>
+                                    {getNumeratorRelations(
+                                        configurations.numerators,
+                                        relation.B
+                                    )}
+                                </TableCell>
+                                <TableCell>
+                                    {getRelationType(relation.type).displayName}
+                                </TableCell>
+                                <TableCell>{relation.criteria}</TableCell>
+                                <TableCell>
+                                    {
+                                        getRelationType(relation.type)
+                                            .thresholdDescription
+                                    }
+                                </TableCell>
+                                <TableCell>
+                                    {getRelationType(relation.type).description}
+                                </TableCell>
+                                <TableCell>
+                                    <Button
+                                        name="Primary button"
+                                        onClick={() => setIsModalHidden(false)}
+                                        basic
+                                        button
+                                        value="default"
+                                        icon={<IconEdit16 />}
+                                    >
+                                        Edit
+                                    </Button>
+                                    <Button
+                                        name="Primary button"
+                                        onClick={() => console.log('It works!')}
+                                        destructive
+                                        button
+                                        value="default"
+                                        icon={<IconDelete16 />}
+                                    >
+                                        Delete
+                                    </Button>
                                 </TableCell>
                             </TableRow>
-                        )}
+                        ))
+                    ) : (
                         <TableRow>
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>
-                            <TableCell>
-                                <Button
-                                    name="Primary button"
-                                    onClick={() => setIsModalHidden(false)}
-                                    primary
-                                    button
-                                    value="default"
-                                    icon={<IconAdd16 />}
-                                >
-                                    {' '}
-                                    Add Numerator Relation
-                                </Button>
-                            </TableCell>
+                            <TableCell>No numerator relations found.</TableCell>
                         </TableRow>
-                    </TableBody>
-                </Table>
-            </div>
+                    )}
+                    <TableRow>
+                        <TableCell></TableCell>
+                        <TableCell></TableCell>
+                        <TableCell></TableCell>
+                        <TableCell></TableCell>
+                        <TableCell></TableCell>
+                        <TableCell></TableCell>
+                        <TableCell></TableCell>
+                        <TableCell>
+                            <Button
+                                name="Primary button"
+                                onClick={() => setIsModalHidden(false)}
+                                primary
+                                button
+                                value="default"
+                                icon={<IconAdd16 />}
+                            >
+                                Add Numerator Relation
+                            </Button>
+                        </TableCell>
+                    </TableRow>
+                </TableBody>
+            </Table>
 
             {/* TODO: will move this modal in it's own component */}
             <Modal
@@ -318,8 +297,7 @@ export const NumeratorRelations = ({ toggleState, configurations }) => {
                             secondary
                             onClick={() => setIsModalHidden(true)}
                         >
-                            {' '}
-                            Cancel{' '}
+                            Cancel
                         </Button>
                         <Button
                             primary
@@ -327,8 +305,7 @@ export const NumeratorRelations = ({ toggleState, configurations }) => {
                                 console.log('creating numerator relations')
                             }
                         >
-                            {' '}
-                            Create{' '}
+                            Create
                         </Button>
                     </ButtonStrip>
                 </ModalActions>
@@ -339,5 +316,4 @@ export const NumeratorRelations = ({ toggleState, configurations }) => {
 
 NumeratorRelations.propTypes = {
     configurations: PropTypes.object,
-    toggleState: PropTypes.string,
 }

--- a/src/utils/numeratorsMetadataData.js
+++ b/src/utils/numeratorsMetadataData.js
@@ -85,7 +85,7 @@ export const getNumeratorsInGroup = (numerators, group, onDeleteNumerator) => {
     )
 }
 
-export const getNumeratorRelations = (numerators, code) => {
+export const getNumeratorNameByCode = (numerators, code) => {
     const numeratorObj = numerators.find((numerator) => numerator.code == code)
     if (numeratorObj) {
         return numeratorObj.name


### PR DESCRIPTION
Still in progress -- did some clean up and started the refactor. Now the entire page doesn't rerender on input change, but the modal still does

Next steps:
- [x] hook up UI for "add new" (the "edit" UI is already there)
- [x] optimize field rerendering with final form
- [x] hook up to the data store API to make changes -- See #42 

Done
- Reorganize some; give Numerator Relations its own dir
- Abstract "edit modal" to its own file to save page rerenders due to form state
- Abstract out `NumeratorRelationsTableItem` to customize modal to each num. rel. item
- Clean up and apply best practices to code