### PR TITLE
feat: generate chart for section 1 [RWDQA-14]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -32,6 +32,12 @@ msgstr "Survey"
 msgid "Org units"
 msgstr "Org units"
 
+msgid "% Completeness"
+msgstr "% Completeness"
+
+msgid "Reporting completeness over time"
+msgstr "Reporting completeness over time"
+
 msgid "Group"
 msgstr "Group"
 

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-11-02T15:06:16.778Z\n"
-"PO-Revision-Date: 2023-11-02T15:06:16.778Z\n"
+"POT-Creation-Date: 2023-11-06T16:07:55.487Z\n"
+"PO-Revision-Date: 2023-11-06T16:07:55.487Z\n"
 
 msgid "Select period(s)"
 msgstr "Select period(s)"
@@ -19,6 +19,24 @@ msgstr "Save"
 
 msgid "No data to display"
 msgstr "No data to display"
+
+msgid "% Completeness"
+msgstr "% Completeness"
+
+msgid "Reporting completeness over time"
+msgstr "Reporting completeness over time"
+
+msgid "Dropout rate (%)"
+msgstr "Dropout rate (%)"
+
+msgid "<b>{{name}}</b><br/>{{value}}% dropout"
+msgstr "<b>{{name}}</b><br/>{{value}}% dropout"
+
+msgid "Org units"
+msgstr "Org units"
+
+msgid "<b>{{name}}</b><br/>{{yLabel}}: {{y}}<br/>{{xLabel}}: {{x}}"
+msgstr "<b>{{name}}</b><br/>{{yLabel}}: {{y}}<br/>{{xLabel}}: {{x}}"
 
 msgid "Chart not available"
 msgstr "Chart not available"
@@ -34,18 +52,6 @@ msgstr "Survey"
 
 msgid "Survey: {{survey}}%<br/>Routine: {{routine}}%"
 msgstr "Survey: {{survey}}%<br/>Routine: {{routine}}%"
-
-msgid "Org units"
-msgstr "Org units"
-
-msgid "% Completeness"
-msgstr "% Completeness"
-
-msgid "Reporting completeness over time"
-msgstr "Reporting completeness over time"
-
-msgid "<b>{{name}}</b><br/>{{yLabel}}: {{y}}<br/>{{xLabel}}: {{x}}"
-msgstr "<b>{{name}}</b><br/>{{yLabel}}: {{y}}<br/>{{xLabel}}: {{x}}"
 
 msgid "Group"
 msgstr "Group"

--- a/src/components/annual-report/generateChart.js
+++ b/src/components/annual-report/generateChart.js
@@ -2,6 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import H from 'highcharts'
 import HB from 'highcharts/modules/bullet'
 import HNDTD from 'highcharts/modules/no-data-to-display'
+import { generateSection1Chart } from './section1/section1ChartGenerator.js'
 import { generateSection3Chart } from './section3/section3ChartGenerator.js'
 import { generateSection4Chart } from './section4/section4ChartGenerator.js'
 
@@ -62,6 +63,10 @@ export const generateChart = (sectionId, canvasId, chartInfo) => {
     let chartConfig
 
     switch (sectionId) {
+        case 'section1': {
+            chartConfig = generateSection1Chart(canvasId, chartInfo)
+            break
+        }
         case 'section3': {
             chartConfig = generateSection3Chart(canvasId, chartInfo)
             break

--- a/src/components/annual-report/section1/SectionOne.js
+++ b/src/components/annual-report/section1/SectionOne.js
@@ -11,6 +11,7 @@ import {
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
+import { Chart } from '../Chart.js'
 import { calculateSection1 } from './section1Calculations.js'
 
 const reportQueries = {
@@ -136,230 +137,294 @@ export const SectionOne = ({ reportParameters }) => {
             <>
                 {/* section one content. this needs to be improved */}
                 {sectionData && (
-                    <div
-                        className="report-preview report-preview-container"
-                        style={{ margin: '26px' }}
-                    >
-                        <p>1a: Completeness of facility reporting</p>
-                        <p>
-                            The percentage of expected reports that have been
-                            entered and completed.
-                        </p>
-                        <Table>
-                            <TableHead>
-                                <TableRowHead>
-                                    <TableCellHead>Data set</TableCellHead>
-                                    <TableCellHead>
-                                        Quality threshold
-                                    </TableCellHead>
-                                    <TableCellHead>Overall score</TableCellHead>
-                                    <TableCellHead colSpan="3">
-                                        Regions with divergent score
-                                        <TableCellHead>Number</TableCellHead>
+                    <>
+                        <div
+                            className="report-preview report-preview-container"
+                            style={{ margin: '26px' }}
+                        >
+                            <p>1a: Completeness of facility reporting</p>
+                            <p>
+                                The percentage of expected reports that have
+                                been entered and completed.
+                            </p>
+                            <Table>
+                                <TableHead>
+                                    <TableRowHead>
+                                        <TableCellHead>Data set</TableCellHead>
                                         <TableCellHead>
-                                            Percentage
+                                            Quality threshold
                                         </TableCellHead>
-                                        <TableCellHead>Name</TableCellHead>
-                                    </TableCellHead>
-                                </TableRowHead>
-                            </TableHead>
-                            <TableBody>
-                                {sectionData.section1A.map((dataset, key) => (
-                                    <TableRow key={key}>
-                                        <TableCell>
-                                            {dataset.dataset_name}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.threshold}%
-                                        </TableCell>
-                                        <TableCell>{dataset.score}%</TableCell>
-                                        <TableCell>
-                                            {dataset.divergentRegionsCount}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.divergentRegionsPercent}%
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.orgUnitLevelsOrGroups.join(
-                                                ', '
-                                            )}
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                        <p>1b: Timeliness of facility reporting</p>
-                        <p>
-                            The percentage of expected reports that have been
-                            entered and completed on time.
-                        </p>
-                        <Table>
-                            <TableHead>
-                                <TableRowHead>
-                                    <TableCellHead>Data set</TableCellHead>
-                                    <TableCellHead>
-                                        Quality threshold
-                                    </TableCellHead>
-                                    <TableCellHead>Overall score</TableCellHead>
-                                    <TableCellHead colSpan="3">
-                                        Regions with divergent score
-                                        <TableCellHead>Number</TableCellHead>
                                         <TableCellHead>
-                                            Percentage
+                                            Overall score
                                         </TableCellHead>
-                                        <TableCellHead>Name</TableCellHead>
-                                    </TableCellHead>
-                                </TableRowHead>
-                            </TableHead>
-                            <TableBody>
-                                {sectionData.section1B.map((dataset, key) => (
-                                    <TableRow key={key}>
-                                        <TableCell>
-                                            {dataset.dataset_name}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.threshold}%
-                                        </TableCell>
-                                        <TableCell>{dataset.score}%</TableCell>
-                                        <TableCell>
-                                            {dataset.divergentRegionsCount}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.divergentRegionsPercent}%
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.orgUnitLevelsOrGroups.join(
-                                                ', '
-                                            )}
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                        <p>1c: Timeliness of facility reporting</p>
-                        <p>
-                            The percentage of expected reports that have been
-                            entered and completed on time.
-                        </p>
-                        <Table>
-                            <TableHead>
-                                <TableRowHead>
-                                    <TableCellHead>Indicator</TableCellHead>
-                                    <TableCellHead>
-                                        Quality threshold
-                                    </TableCellHead>
-                                    <TableCellHead colSpan="2">
-                                        Values
-                                        <TableCellHead>Expected</TableCellHead>
-                                        <TableCellHead>Actual</TableCellHead>
-                                    </TableCellHead>
-                                    <TableCellHead>Overall Score</TableCellHead>
-                                    <TableCellHead colSpan="3">
-                                        Regions with divergent score
-                                        <TableCellHead>Number</TableCellHead>
+                                        <TableCellHead colSpan="3">
+                                            Regions with divergent score
+                                            <TableCellHead>
+                                                Number
+                                            </TableCellHead>
+                                            <TableCellHead>
+                                                Percentage
+                                            </TableCellHead>
+                                            <TableCellHead>Name</TableCellHead>
+                                        </TableCellHead>
+                                    </TableRowHead>
+                                </TableHead>
+                                <TableBody>
+                                    {sectionData.section1A.map(
+                                        (dataset, key) => (
+                                            <TableRow key={key}>
+                                                <TableCell>
+                                                    {dataset.dataset_name}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.threshold}%
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.score}%
+                                                </TableCell>
+                                                <TableCell>
+                                                    {
+                                                        dataset.divergentRegionsCount
+                                                    }
+                                                </TableCell>
+                                                <TableCell>
+                                                    {
+                                                        dataset.divergentRegionsPercent
+                                                    }
+                                                    %
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.orgUnitLevelsOrGroups.join(
+                                                        ', '
+                                                    )}
+                                                </TableCell>
+                                            </TableRow>
+                                        )
+                                    )}
+                                </TableBody>
+                            </Table>
+                            <p>1b: Timeliness of facility reporting</p>
+                            <p>
+                                The percentage of expected reports that have
+                                been entered and completed on time.
+                            </p>
+                            <Table>
+                                <TableHead>
+                                    <TableRowHead>
+                                        <TableCellHead>Data set</TableCellHead>
                                         <TableCellHead>
-                                            Percentage
+                                            Quality threshold
                                         </TableCellHead>
-                                        <TableCellHead>Name</TableCellHead>
-                                    </TableCellHead>
-                                </TableRowHead>
-                            </TableHead>
-                            <TableBody>
-                                {sectionData.section1C.map((dataset, key) => (
-                                    <TableRow key={key}>
-                                        <TableCell>
-                                            {dataset.indicator_name}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.threshold}%
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.expectedValues}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.actualValues}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.overallScore}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.divergentRegionsCount}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.divergentRegionsPercent}%
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.orgUnitLevelsOrGroups.join(
-                                                ', '
-                                            )}
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
+                                        <TableCellHead>
+                                            Overall score
+                                        </TableCellHead>
+                                        <TableCellHead colSpan="3">
+                                            Regions with divergent score
+                                            <TableCellHead>
+                                                Number
+                                            </TableCellHead>
+                                            <TableCellHead>
+                                                Percentage
+                                            </TableCellHead>
+                                            <TableCellHead>Name</TableCellHead>
+                                        </TableCellHead>
+                                    </TableRowHead>
+                                </TableHead>
+                                <TableBody>
+                                    {sectionData.section1B.map(
+                                        (dataset, key) => (
+                                            <TableRow key={key}>
+                                                <TableCell>
+                                                    {dataset.dataset_name}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.threshold}%
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.score}%
+                                                </TableCell>
+                                                <TableCell>
+                                                    {
+                                                        dataset.divergentRegionsCount
+                                                    }
+                                                </TableCell>
+                                                <TableCell>
+                                                    {
+                                                        dataset.divergentRegionsPercent
+                                                    }
+                                                    %
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.orgUnitLevelsOrGroups.join(
+                                                        ', '
+                                                    )}
+                                                </TableCell>
+                                            </TableRow>
+                                        )
+                                    )}
+                                </TableBody>
+                            </Table>
+                            <p>1c: Timeliness of facility reporting</p>
+                            <p>
+                                The percentage of expected reports that have
+                                been entered and completed on time.
+                            </p>
+                            <Table>
+                                <TableHead>
+                                    <TableRowHead>
+                                        <TableCellHead>Indicator</TableCellHead>
+                                        <TableCellHead>
+                                            Quality threshold
+                                        </TableCellHead>
+                                        <TableCellHead colSpan="2">
+                                            Values
+                                            <TableCellHead>
+                                                Expected
+                                            </TableCellHead>
+                                            <TableCellHead>
+                                                Actual
+                                            </TableCellHead>
+                                        </TableCellHead>
+                                        <TableCellHead>
+                                            Overall Score
+                                        </TableCellHead>
+                                        <TableCellHead colSpan="3">
+                                            Regions with divergent score
+                                            <TableCellHead>
+                                                Number
+                                            </TableCellHead>
+                                            <TableCellHead>
+                                                Percentage
+                                            </TableCellHead>
+                                            <TableCellHead>Name</TableCellHead>
+                                        </TableCellHead>
+                                    </TableRowHead>
+                                </TableHead>
+                                <TableBody>
+                                    {sectionData.section1C.map(
+                                        (dataset, key) => (
+                                            <TableRow key={key}>
+                                                <TableCell>
+                                                    {dataset.indicator_name}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.threshold}%
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.expectedValues}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.actualValues}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.overallScore}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {
+                                                        dataset.divergentRegionsCount
+                                                    }
+                                                </TableCell>
+                                                <TableCell>
+                                                    {
+                                                        dataset.divergentRegionsPercent
+                                                    }
+                                                    %
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.orgUnitLevelsOrGroups.join(
+                                                        ', '
+                                                    )}
+                                                </TableCell>
+                                            </TableRow>
+                                        )
+                                    )}
+                                </TableBody>
+                            </Table>
 
-                        <p>1d: Consistency of dataset completeness over time</p>
-                        <p>
-                            Completeness of datasets in 2022 compared to
-                            previous 3 years.
-                        </p>
-                        <Table>
-                            <TableHead>
-                                <TableRowHead>
-                                    <TableCellHead>Data set</TableCellHead>
-                                    <TableCellHead>
-                                        Expected Trend
-                                    </TableCellHead>
-                                    <TableCellHead>
-                                        Compare Region to
-                                    </TableCellHead>
-                                    <TableCellHead>
-                                        Quality threshold
-                                    </TableCellHead>
-                                    <TableCellHead>Overall score</TableCellHead>
-                                    <TableCellHead colSpan="3">
-                                        Regions with divergent score
-                                        <TableCellHead>Number</TableCellHead>
+                            <p>
+                                1d: Consistency of dataset completeness over
+                                time
+                            </p>
+                            <p>
+                                Completeness of datasets in 2022 compared to
+                                previous 3 years.
+                            </p>
+                            <Table>
+                                <TableHead>
+                                    <TableRowHead>
+                                        <TableCellHead>Data set</TableCellHead>
                                         <TableCellHead>
-                                            Percentage
+                                            Expected Trend
                                         </TableCellHead>
-                                        <TableCellHead>Name</TableCellHead>
-                                    </TableCellHead>
-                                </TableRowHead>
-                            </TableHead>
-                            <TableBody>
-                                {sectionData.section1D.map((dataset, key) => (
-                                    <TableRow key={key}>
-                                        <TableCell>
-                                            {dataset.dataset_name}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.trend[0].toUpperCase() +
-                                                dataset.trend.slice(1)}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.comparison}
-                                        </TableCell>
-                                        <TableCell>
-                                            ± {dataset.threshold}%
-                                        </TableCell>
-                                        <TableCell>{dataset.score}%</TableCell>
-                                        <TableCell>
-                                            {dataset.divergentRegionsCount}
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.divergentRegionsPercent}%
-                                        </TableCell>
-                                        <TableCell>
-                                            {dataset.orgUnitLevelsOrGroups.join(
-                                                ', '
-                                            )}
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                    </div>
+                                        <TableCellHead>
+                                            Compare Region to
+                                        </TableCellHead>
+                                        <TableCellHead>
+                                            Quality threshold
+                                        </TableCellHead>
+                                        <TableCellHead>
+                                            Overall score
+                                        </TableCellHead>
+                                        <TableCellHead colSpan="3">
+                                            Regions with divergent score
+                                            <TableCellHead>
+                                                Number
+                                            </TableCellHead>
+                                            <TableCellHead>
+                                                Percentage
+                                            </TableCellHead>
+                                            <TableCellHead>Name</TableCellHead>
+                                        </TableCellHead>
+                                    </TableRowHead>
+                                </TableHead>
+                                <TableBody>
+                                    {sectionData.section1D.map(
+                                        (dataset, key) => (
+                                            <TableRow key={key}>
+                                                <TableCell>
+                                                    {dataset.dataset_name}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.trend[0].toUpperCase() +
+                                                        dataset.trend.slice(1)}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.comparison}
+                                                </TableCell>
+                                                <TableCell>
+                                                    ± {dataset.threshold}%
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.score}%
+                                                </TableCell>
+                                                <TableCell>
+                                                    {
+                                                        dataset.divergentRegionsCount
+                                                    }
+                                                </TableCell>
+                                                <TableCell>
+                                                    {
+                                                        dataset.divergentRegionsPercent
+                                                    }
+                                                    %
+                                                </TableCell>
+                                                <TableCell>
+                                                    {dataset.orgUnitLevelsOrGroups.join(
+                                                        ', '
+                                                    )}
+                                                </TableCell>
+                                            </TableRow>
+                                        )
+                                    )}
+                                </TableBody>
+                            </Table>
+                        </div>
+                        <Chart
+                            sectionId={'section1'}
+                            chartId={'chart1'}
+                            chartInfo={sectionData.chartInfo}
+                        />
+                    </>
                 )}
             </>
         )

--- a/src/components/annual-report/section1/section1ChartGenerator.js
+++ b/src/components/annual-report/section1/section1ChartGenerator.js
@@ -1,0 +1,29 @@
+import i18n from '@dhis2/d2-i18n'
+
+export const generateSection1Chart = (canvasId, chartInfo) => {
+    const series = chartInfo.values.map(({ points, name }) => ({
+        name,
+        data: points,
+    }))
+
+    return {
+        chart: {
+            renderTo: canvasId,
+            type: 'line',
+        },
+        series,
+        xAxis: [{ categories: chartInfo.x }],
+        yAxis: [
+            {
+                min: 0,
+                softMax: 100,
+                title: {
+                    text: i18n.t('% Completeness'),
+                },
+            },
+        ],
+        title: {
+            text: i18n.t('Reporting completeness over time'),
+        },
+    }
+}


### PR DESCRIPTION
This PR (for ticket https://dhis2.atlassian.net/browse/RWDQA-14)

- implements functions for generating chart (multiple lines) needed in Section 1

Chart screenshots:
Multiple line chart with some missing values:
<img width="1038" alt="Screenshot 2023-11-02 at 11 09 45" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/8ec2bac4-b87b-4a6f-8161-59c71f9ea08e">

Example of 1 line highlighted by hovering on the correspondent item in the legend:
<img width="1031" alt="Screenshot 2023-11-02 at 11 13 04" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/2a34d729-fd3f-44d6-8412-5c32079a0d15">


