### PR TITLE
feat: generate charts for section 2 [RWDQA-14]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-11-02T09:47:40.459Z\n"
-"PO-Revision-Date: 2023-11-02T09:47:40.459Z\n"
+"POT-Creation-Date: 2023-11-02T15:06:16.778Z\n"
+"PO-Revision-Date: 2023-11-02T15:06:16.778Z\n"
 
 msgid "Select period(s)"
 msgstr "Select period(s)"
@@ -23,14 +23,23 @@ msgstr "No data to display"
 msgid "Chart not available"
 msgstr "Chart not available"
 
+msgid "<b>{{name}}</b><br/>Survey: {{survey}}%<br/>Routine: {{routine}}%"
+msgstr "<b>{{name}}</b><br/>Survey: {{survey}}%<br/>Routine: {{routine}}%"
+
 msgid "Routine"
 msgstr "Routine"
 
 msgid "Survey"
 msgstr "Survey"
 
+msgid "Survey: {{survey}}%<br/>Routine: {{routine}}%"
+msgstr "Survey: {{survey}}%<br/>Routine: {{routine}}%"
+
 msgid "Org units"
 msgstr "Org units"
+
+msgid "<b>{{name}}</b><br/>{{yLabel}}: {{y}}<br/>{{xLabel}}: {{x}}"
+msgstr "<b>{{name}}</b><br/>{{yLabel}}: {{y}}<br/>{{xLabel}}: {{x}}"
 
 msgid "Group"
 msgstr "Group"

--- a/src/components/annual-report/generateChart.js
+++ b/src/components/annual-report/generateChart.js
@@ -2,6 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import H from 'highcharts'
 import HB from 'highcharts/modules/bullet'
 import HNDTD from 'highcharts/modules/no-data-to-display'
+import { generateSection2Chart } from './section2/section2ChartGenerator.js'
 import { generateSection3Chart } from './section3/section3ChartGenerator.js'
 import { generateSection4Chart } from './section4/section4ChartGenerator.js'
 
@@ -62,6 +63,11 @@ export const generateChart = (sectionId, canvasId, chartInfo) => {
     let chartConfig
 
     switch (sectionId) {
+        case 'section2d':
+        case 'section2e': {
+            chartConfig = generateSection2Chart(canvasId, chartInfo)
+            break
+        }
         case 'section3': {
             chartConfig = generateSection3Chart(canvasId, chartInfo)
             break

--- a/src/components/annual-report/section2/SectionTwo.js
+++ b/src/components/annual-report/section2/SectionTwo.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
+import { Chart } from '../Chart.js'
 import { calculateSection2 } from './section2Calculations.js'
 import { useFetchSectionTwoData } from './useFetchSectionTwoData.js'
 
@@ -89,40 +90,95 @@ Sections2a2b2c.propTypes = {
 }
 
 const Section2DBlock = ({ dataRow }) => (
-    <table>
-        <tbody>
-            <tr>
-                <th colSpan="2">{dataRow.name}</th>
-            </tr>
-            <tr>
-                <td>Expected trend</td>
-                <td>{dataRow.expectedTrend}</td>
-            </tr>
-            <tr>
-                <td>Compare region to</td>
-                <td>{dataRow.compareRegionTo}</td>
-            </tr>
-            <tr>
-                <td>Quality threshold</td>
-                <td>±{dataRow.qualityThreshold}%</td>
-            </tr>
-            <tr>
-                <td>Overall score</td>
-                <td>{dataRow.overallScore}%</td>
-            </tr>
-            <tr>
-                <td>Number of Region with divergent score</td>
-                <td>{dataRow.divergentSubOrgUnits?.number}</td>
-            </tr>
-            <tr>
-                <td>Percent of Region with divergent score</td>
-                <td>{dataRow.divergentSubOrgUnits?.percent}%</td>
-            </tr>
-            <tr>
-                <td colSpan="2">{dataRow.divergentSubOrgUnits?.names}</td>
-            </tr>
-        </tbody>
-    </table>
+    <>
+        <table>
+            <tbody>
+                <tr>
+                    <th colSpan="2">{dataRow.name}</th>
+                </tr>
+                <tr>
+                    <td>Expected trend</td>
+                    <td>{dataRow.expectedTrend}</td>
+                </tr>
+                <tr>
+                    <td>Compare region to</td>
+                    <td>{dataRow.compareRegionTo}</td>
+                </tr>
+                <tr>
+                    <td>Quality threshold</td>
+                    <td>±{dataRow.qualityThreshold}%</td>
+                </tr>
+                <tr>
+                    <td>Overall score</td>
+                    <td>{dataRow.overallScore}%</td>
+                </tr>
+                <tr>
+                    <td>Number of Region with divergent score</td>
+                    <td>{dataRow.divergentSubOrgUnits?.number}</td>
+                </tr>
+                <tr>
+                    <td>Percent of Region with divergent score</td>
+                    <td>{dataRow.divergentSubOrgUnits?.percent}%</td>
+                </tr>
+                <tr>
+                    <td colSpan="2">{dataRow.divergentSubOrgUnits?.names}</td>
+                </tr>
+            </tbody>
+        </table>
+        <Chart
+            sectionId={'section2d'}
+            chartId={'chart1'}
+            chartInfo={{
+                type: 'line',
+                xPointLabel: 'Albendazole 1 dose at ANC',
+                x: ['2019', '2020', '2021', '2022'],
+                y: [65822, 247661, 326583, 368306],
+            }}
+        />
+        <Chart
+            sectionId={'section2d'}
+            chartId={'chart2'}
+            chartInfo={{
+                type: 'scatter',
+                slope: 1.9,
+                threshold: 33,
+                xAxisTitle: 'Average of 3 previous periods',
+                lineLabel: 'Current=Average',
+                yAxisTitle: '2022',
+                xPointLabel: 'Average',
+                values: [
+                    {
+                        name: 'Region A',
+                        x: 35845.7,
+                        y: 60539,
+                        divergent: false,
+                        invalid: false,
+                    },
+                    {
+                        name: 'Region B',
+                        x: 47031.3,
+                        y: 75453,
+                        divergent: false,
+                        invalid: false,
+                    },
+                    {
+                        name: 'Region C',
+                        x: 58226,
+                        y: 137034,
+                        divergent: false,
+                        invalid: false,
+                    },
+                    {
+                        name: 'Region D',
+                        x: 69649,
+                        y: 124386,
+                        divergent: false,
+                        invalid: false,
+                    },
+                ],
+            }}
+        />
+    </>
 )
 
 Section2DBlock.propTypes = {
@@ -149,47 +205,103 @@ Section2D.propTypes = {
 }
 
 const Section2EBlock = ({ dataRow }) => (
-    <table>
-        <tbody>
-            <tr>
-                <th colSpan="2">{dataRow.title}</th>
-            </tr>
-            <tr>
-                <td>Denominator A</td>
-                <td>{dataRow.A}</td>
-            </tr>
-            <tr>
-                <td>Denominator B</td>
-                <td>{dataRow.B}</td>
-            </tr>
-            <tr>
-                <td>Expected relationship</td>
-                <td>{dataRow.expectedRelationship}</td>
-            </tr>
-            <tr>
-                <td>Quality threshold</td>
-                <td>
-                    {dataRow.expectedRelationship === 'Dropout rate' ? '' : '±'}
-                    {dataRow.qualityThreshold}
-                </td>
-            </tr>
-            <tr>
-                <td>Overall score</td>
-                <td>{dataRow.overallScore}%</td>
-            </tr>
-            <tr>
-                <td>Number of Region with divergent score</td>
-                <td>{dataRow.divergentSubOrgUnits?.number}</td>
-            </tr>
-            <tr>
-                <td>Percent of Region with divergent score</td>
-                <td>{dataRow.divergentSubOrgUnits?.percentage}%</td>
-            </tr>
-            <tr>
-                <td colSpan="2">{dataRow.divergentSubOrgUnits?.names}</td>
-            </tr>
-        </tbody>
-    </table>
+    <>
+        <table>
+            <tbody>
+                <tr>
+                    <th colSpan="2">{dataRow.title}</th>
+                </tr>
+                <tr>
+                    <td>Denominator A</td>
+                    <td>{dataRow.A}</td>
+                </tr>
+                <tr>
+                    <td>Denominator B</td>
+                    <td>{dataRow.B}</td>
+                </tr>
+                <tr>
+                    <td>Expected relationship</td>
+                    <td>{dataRow.expectedRelationship}</td>
+                </tr>
+                <tr>
+                    <td>Quality threshold</td>
+                    <td>
+                        {dataRow.expectedRelationship === 'Dropout rate'
+                            ? ''
+                            : '±'}
+                        {dataRow.qualityThreshold}
+                    </td>
+                </tr>
+                <tr>
+                    <td>Overall score</td>
+                    <td>{dataRow.overallScore}%</td>
+                </tr>
+                <tr>
+                    <td>Number of Region with divergent score</td>
+                    <td>{dataRow.divergentSubOrgUnits?.number}</td>
+                </tr>
+                <tr>
+                    <td>Percent of Region with divergent score</td>
+                    <td>{dataRow.divergentSubOrgUnits?.percentage}%</td>
+                </tr>
+                <tr>
+                    <td colSpan="2">{dataRow.divergentSubOrgUnits?.names}</td>
+                </tr>
+            </tbody>
+        </table>
+        <Chart
+            sectionId={'section2e'}
+            chartId={'chart1'}
+            chartInfo={{
+                disableTopThresholdLine: true,
+                type: 'scatter',
+                slope: 1,
+                threshold: 30,
+                xAxisTitle: 'Penta 1 given < 1',
+                xPointLabel: 'Penta 1 given < 1',
+                lineLabel: 'National',
+                yAxisTitle: 'ANC 1 Visits',
+                values: [
+                    {
+                        name: 'Region A',
+                        x: 63373,
+                        y: 72003,
+                        divergent: true,
+                        invalid: false,
+                    },
+                ],
+            }}
+        />
+        <Chart
+            sectionId={'section2e'}
+            chartId={'chart2'}
+            chartInfo={{
+                type: 'column',
+                values: [
+                    {
+                        name: 'Region A',
+                        value: 80.83,
+                        invalid: false,
+                    },
+                    {
+                        name: 'Region B',
+                        value: 78.93,
+                        invalid: false,
+                    },
+                    {
+                        name: 'Region C',
+                        value: 79.99,
+                        invalid: false,
+                    },
+                    {
+                        name: 'Region D',
+                        value: -10,
+                        invalid: false,
+                    },
+                ],
+            }}
+        />
+    </>
 )
 
 Section2EBlock.propTypes = {

--- a/src/components/annual-report/section2/section2ChartGenerator.js
+++ b/src/components/annual-report/section2/section2ChartGenerator.js
@@ -1,0 +1,195 @@
+import i18n from '@dhis2/d2-i18n'
+
+export const generateSection2Chart = (canvasId, chartInfo) => {
+    switch (chartInfo.type) {
+        case 'line':
+            return generateLineChartConfig(canvasId, chartInfo)
+        case 'scatter':
+            return generateScatterChartConfig(canvasId, chartInfo)
+        case 'column':
+            return generateColumnChartConfig(canvasId, chartInfo)
+    }
+}
+
+const generateLineChartConfig = (canvasId, chartInfo) => ({
+    chart: {
+        renderTo: canvasId,
+        type: 'line',
+    },
+    series: [
+        {
+            name: chartInfo.xPointLabel,
+            data: chartInfo.y,
+        },
+    ],
+    xAxis: {
+        categories: chartInfo.x,
+    },
+    yAxis: {
+        title: {
+            text: undefined,
+        },
+    },
+    legend: {
+        enabled: false,
+    },
+})
+
+const generateColumnChartConfig = (canvasId, chartInfo) => {
+    const categories = []
+    const data = []
+
+    chartInfo.values
+        .filter(({ invalid }) => !invalid)
+        .forEach(({ value, name }) => {
+            categories.push(name)
+            data.push({
+                y: value,
+                custom: {
+                    name,
+                },
+            })
+        })
+
+    return {
+        chart: {
+            renderTo: canvasId,
+            type: 'column',
+        },
+        series: [
+            {
+                data,
+                color: 'rgb(87,153,199)',
+                negativeColor: 'rgb(255,62,64)',
+            },
+        ],
+        xAxis: {
+            categories,
+        },
+        yAxis: {
+            title: {
+                text: i18n.t('Dropout rate (%)'),
+            },
+        },
+        legend: {
+            enabled: false,
+        },
+        tooltip: {
+            headerFormat: '',
+            pointFormatter: function () {
+                return i18n.t('<b>{{name}}</b><br/>{{value}}% dropout', {
+                    name: this.custom.name,
+                    value: this.y,
+                })
+            },
+        },
+    }
+}
+
+const generateScatterChartConfig = (canvasId, chartInfo) => {
+    const dataPoints = chartInfo.values
+        .filter(({ invalid }) => !invalid)
+        .map(({ x, y, divergent, name }) => ({
+            x,
+            y,
+            marker: {
+                symbol: divergent ? 'diamond' : 'circle',
+            },
+            custom: {
+                name,
+                xLabel: chartInfo.xPointLabel,
+                yLabel: chartInfo.yAxisTitle,
+            },
+        }))
+
+    const xMax = Math.max(...dataPoints.flatMap(({ x }) => x))
+    const xMaxThreshold = xMax * (chartInfo.threshold / 100)
+
+    const series = [
+        {
+            name: i18n.t('Org units'),
+            data: dataPoints,
+            color: 'rgb(31,119,180)',
+        },
+        {
+            type: 'line',
+            name: chartInfo.lineLabel,
+            data: dataPoints.length
+                ? [0, { x: xMax, y: xMax * chartInfo.slope }]
+                : [],
+            color: 'black',
+            marker: { enabled: false },
+            enableMouseTracking: false,
+        },
+        {
+            type: 'line',
+            name: `- ${chartInfo.threshold}%`,
+            data: dataPoints.length
+                ? [0, { x: xMax, y: (xMax - xMaxThreshold) * chartInfo.slope }]
+                : [],
+            color: 'rgb(176,176,176)',
+            marker: { enabled: false },
+            enableMouseTracking: false,
+        },
+    ]
+
+    if (!chartInfo.disableTopThresholdLine) {
+        series.splice(2, 0, {
+            type: 'line',
+            name: `+ ${chartInfo.threshold}%`,
+            data: dataPoints.length
+                ? [0, { x: xMax, y: (xMax + xMaxThreshold) * chartInfo.slope }]
+                : [],
+            color: 'rgb(176,176,176)',
+            marker: { enabled: false },
+            enableMouseTracking: false,
+        })
+    }
+
+    return {
+        chart: {
+            renderTo: canvasId,
+            type: 'scatter',
+        },
+        series,
+        xAxis: [
+            {
+                min: 0,
+                title: {
+                    text: chartInfo.xAxisTitle,
+                },
+            },
+        ],
+        yAxis: [
+            {
+                min: 0,
+                title: {
+                    text: chartInfo.yAxisTitle,
+                },
+            },
+        ],
+        plotOptions: {
+            series: {
+                marker: {
+                    symbol: 'circle',
+                },
+            },
+        },
+        tooltip: {
+            headerFormat: '',
+            pointFormatter: function () {
+                return i18n.t(
+                    '<b>{{name}}</b><br/>{{yLabel}}: {{y}}<br/>{{xLabel}}: {{x}}',
+                    {
+                        name: this.custom.name,
+                        yLabel: this.custom.yLabel,
+                        y: this.y,
+                        xLabel: this.custom.xLabel,
+                        x: this.x,
+                        nsSeparator: '-:-',
+                    }
+                )
+            },
+        },
+    }
+}

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -76,6 +76,8 @@ const generateBulletChartConfig = (canvasId, chartInfo) => {
 }
 
 const generateScatterChartConfig = (canvasId, chartInfo) => {
+    const categories = []
+
     const routineSeries = {
         name: i18n.t('Routine'),
         color: 'blue',
@@ -89,7 +91,9 @@ const generateScatterChartConfig = (canvasId, chartInfo) => {
 
     chartInfo.values
         .filter(({ invalid }) => !invalid)
-        .forEach(({ routine, survey, divergent }) => {
+        .forEach(({ name, routine, survey, divergent }) => {
+            categories.push(name)
+
             routineSeries.data.push({
                 y: routine,
                 custom: {
@@ -117,7 +121,7 @@ const generateScatterChartConfig = (canvasId, chartInfo) => {
             type: 'scatter',
         },
         xAxis: {
-            categories: chartInfo.values.map(({ name }) => name),
+            categories,
         },
         yAxis: {
             title: {

--- a/src/components/annual-report/section3/section3ChartGenerator.js
+++ b/src/components/annual-report/section3/section3ChartGenerator.js
@@ -67,6 +67,7 @@ const generateBulletChartConfig = (canvasId, chartInfo) => {
                         name: this.custom.name,
                         survey: this.target,
                         routine: this.y,
+                        nsSeparator: '-:-',
                     }
                 )
             },
@@ -130,8 +131,15 @@ const generateScatterChartConfig = (canvasId, chartInfo) => {
             headerFormat: '<b>{point.key}</b><br/>',
             pointFormatter: function () {
                 return i18n.t('Survey: {{survey}}%<br/>Routine: {{routine}}%', {
-                    survey: this.custom.survey ?? this.y,
-                    routine: this.custom.routine ?? this.y,
+                    survey:
+                        this.custom.survey !== undefined
+                            ? this.custom.survey
+                            : this.y,
+                    routine:
+                        this.custom.routine !== undefined
+                            ? this.custom.routine
+                            : this.y,
+                    nsSeparator: '-:-',
                 })
             },
         },

--- a/src/components/annual-report/section4/section4ChartGenerator.js
+++ b/src/components/annual-report/section4/section4ChartGenerator.js
@@ -93,6 +93,7 @@ export const generateSection4Chart = (canvasId, chartInfo) => {
                         y: this.y,
                         xLabel: this.custom.xLabel,
                         x: this.x,
+                        nsSeparator: '-:-',
                     }
                 )
             },


### PR DESCRIPTION
This PR (for ticket https://dhis2.atlassian.net/browse/RWDQA-14)

- implements functions for generating charts (line, column and scatter) needed in Section 2

**NB**: `SectionTwo.js` has inline sample data that needs to be removed once the logic is in place.
For section 2e, only one `<Chart />` component is needed (the second is there only for testing the column chart).

Line chart screenshot:
<img width="904" alt="Screenshot 2023-11-03 at 10 42 15" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/346b35f0-cddc-4885-bfc4-d2974a76e8ea">

Scatter chart screenshot:
<img width="901" alt="Screenshot 2023-11-03 at 10 42 05" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/ce243eb7-53f9-449a-8f61-b19f5973afad">

Column chart screenshot:
<img width="888" alt="Screenshot 2023-11-03 at 10 41 34" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/150978/76320522-720c-4610-9dd9-bc07a5ffa9d7">


