### PR TITLE
fix: handle missing info [RWDQA-59]

### DIFF
--- a/src/components/annual-report/section1/SectionOne.js
+++ b/src/components/annual-report/section1/SectionOne.js
@@ -134,7 +134,6 @@ export const SectionOne = ({ reportParameters }) => {
             periodsIDs: reportParameters.periods.map((p) => p.id),
             overallOrgUnit: reportParameters.orgUnits[0],
         })
-
         return (
             <>
                 {/* section one content. this needs to be improved */}
@@ -176,29 +175,30 @@ export const SectionOne = ({ reportParameters }) => {
                                         (dataset, key) => (
                                             <TableRow key={key}>
                                                 <TableCell>
-                                                    {dataset.dataset_name}
+                                                    {dataset?.dataset_name}
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.threshold}%
+                                                    {dataset?.threshold}%
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.score}%
+                                                    {dataset?.score}%
                                                 </TableCell>
                                                 <TableCell>
                                                     {
-                                                        dataset.divergentRegionsCount
+                                                        dataset?.divergentRegionsCount
                                                     }
                                                 </TableCell>
                                                 <TableCell>
                                                     {
-                                                        dataset.divergentRegionsPercent
+                                                        dataset?.divergentRegionsPercent
                                                     }
                                                     %
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.orgUnitLevelsOrGroups.join(
-                                                        ', '
-                                                    )}
+                                                    {(
+                                                        dataset?.orgUnitLevelsOrGroups ??
+                                                        []
+                                                    ).join(', ')}
                                                 </TableCell>
                                             </TableRow>
                                         )
@@ -237,29 +237,30 @@ export const SectionOne = ({ reportParameters }) => {
                                         (dataset, key) => (
                                             <TableRow key={key}>
                                                 <TableCell>
-                                                    {dataset.dataset_name}
+                                                    {dataset?.dataset_name}
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.threshold}%
+                                                    {dataset?.threshold}%
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.score}%
+                                                    {dataset?.score}%
                                                 </TableCell>
                                                 <TableCell>
                                                     {
-                                                        dataset.divergentRegionsCount
+                                                        dataset?.divergentRegionsCount
                                                     }
                                                 </TableCell>
                                                 <TableCell>
                                                     {
-                                                        dataset.divergentRegionsPercent
+                                                        dataset?.divergentRegionsPercent
                                                     }
                                                     %
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.orgUnitLevelsOrGroups.join(
-                                                        ', '
-                                                    )}
+                                                    {(
+                                                        dataset?.orgUnitLevelsOrGroups ??
+                                                        []
+                                                    ).join(', ')}
                                                 </TableCell>
                                             </TableRow>
                                         )
@@ -307,35 +308,36 @@ export const SectionOne = ({ reportParameters }) => {
                                         (dataset, key) => (
                                             <TableRow key={key}>
                                                 <TableCell>
-                                                    {dataset.indicator_name}
+                                                    {dataset?.indicator_name}
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.threshold}%
+                                                    {dataset?.threshold}%
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.expectedValues}
+                                                    {dataset?.expectedValues}
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.actualValues}
+                                                    {dataset?.actualValues}
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.overallScore}
+                                                    {dataset?.overallScore}
                                                 </TableCell>
                                                 <TableCell>
                                                     {
-                                                        dataset.divergentRegionsCount
+                                                        dataset?.divergentRegionsCount
                                                     }
                                                 </TableCell>
                                                 <TableCell>
                                                     {
-                                                        dataset.divergentRegionsPercent
+                                                        dataset?.divergentRegionsPercent
                                                     }
                                                     %
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.orgUnitLevelsOrGroups.join(
-                                                        ', '
-                                                    )}
+                                                    {(
+                                                        dataset?.orgUnitLevelsOrGroups ??
+                                                        []
+                                                    ).join(', ')}
                                                 </TableCell>
                                             </TableRow>
                                         )
@@ -384,36 +386,39 @@ export const SectionOne = ({ reportParameters }) => {
                                         (dataset, key) => (
                                             <TableRow key={key}>
                                                 <TableCell>
-                                                    {dataset.dataset_name}
+                                                    {dataset?.dataset_name}
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.trend[0].toUpperCase() +
-                                                        dataset.trend.slice(1)}
+                                                    {dataset?.trend?.[0]?.toUpperCase() +
+                                                        dataset?.trend?.slice(
+                                                            1
+                                                        )}
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.comparison}
+                                                    {dataset?.comparison}
                                                 </TableCell>
                                                 <TableCell>
-                                                    ± {dataset.threshold}%
+                                                    ± {dataset?.threshold}%
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.score}%
+                                                    {dataset?.score}%
                                                 </TableCell>
                                                 <TableCell>
                                                     {
-                                                        dataset.divergentRegionsCount
+                                                        dataset?.divergentRegionsCount
                                                     }
                                                 </TableCell>
                                                 <TableCell>
                                                     {
-                                                        dataset.divergentRegionsPercent
+                                                        dataset?.divergentRegionsPercent
                                                     }
                                                     %
                                                 </TableCell>
                                                 <TableCell>
-                                                    {dataset.orgUnitLevelsOrGroups.join(
-                                                        ', '
-                                                    )}
+                                                    {(
+                                                        dataset?.orgUnitLevelsOrGroups ??
+                                                        []
+                                                    ).join(', ')}
                                                 </TableCell>
                                             </TableRow>
                                         )

--- a/src/components/annual-report/section1/section1Calculations.js
+++ b/src/components/annual-report/section1/section1Calculations.js
@@ -172,20 +172,21 @@ const getJsonObjectsFormatFromTableFormat = ({
         // adding thresholds where they are not
         if (calculatingFor == 'section1A') {
             rowData['threshold'] =
-                mappedConfigurations.dataSets[currentDataSetId].threshold
+                mappedConfigurations?.dataSets?.[currentDataSetId]?.threshold
         } else if (calculatingFor == 'section1B') {
             rowData['threshold'] =
-                mappedConfigurations.dataSets[
+                mappedConfigurations?.dataSets?.[
                     currentDataSetId
-                ].timelinessThreshold
+                ]?.timelinessThreshold
         } else if (calculatingFor == 'section1D') {
             const comparison =
-                mappedConfigurations.dataSets[currentDataSetId].comparison
-            const trend = mappedConfigurations.dataSets[currentDataSetId].trend
+                mappedConfigurations?.dataSets?.[currentDataSetId]?.comparison
+            const trend =
+                mappedConfigurations?.dataSets?.[currentDataSetId]?.trend
             rowData['threshold'] =
-                mappedConfigurations.dataSets[
+                mappedConfigurations?.dataSets?.[
                     currentDataSetId
-                ].consistencyThreshold
+                ]?.consistencyThreshold
             rowData['trend'] = trend
 
             if (comparison === 'th' && trend === 'constant') {
@@ -237,8 +238,8 @@ const getJsonObjectsFormatFromTableFormat = ({
 // Function to find the numerator
 const findNumerator = (numerators, dataElementID) => {
     return (
-        numerators[dataElementID] ||
-        Object.values(numerators).find((item) => {
+        numerators?.[dataElementID] ||
+        Object.values(numerators ?? {}).find((item) => {
             const parts = item.dataElementOperandID.split('.')
             return parts.length > 1 && parts[0] === dataElementID
         })
@@ -325,9 +326,9 @@ const getJsonObjectsFormatFromTableFormat_DataValues = ({
         const pe = rowData.pe
 
         const currentNumerator = findNumerator(
-            mappedConfigurations.dataElementsAndIndicators,
+            mappedConfigurations?.dataElementsAndIndicators,
             dx
-        )
+        ) ?? { dataSetID: [] } // initiate empty object to prevent errors if numerator is missing
 
         if (!restructuredData[dx]) {
             restructuredData[dx] = {}
@@ -350,7 +351,7 @@ const getJsonObjectsFormatFromTableFormat_DataValues = ({
         //TODO: most values here are not needed while working on count_of_data_values_by_org_unit_level, will find a suitable condition to ignore them
         //construct the object for each
         restructuredData[dx][pe].push({
-            threshold: currentNumerator.missing, // get this from missing value calculate these above in rows
+            threshold: currentNumerator?.missing, // get this from missing value calculate these above in rows
             expectedValues: parseFloat(expectedValues),
             actualValues: parseInt(rowData.value),
             overallScore: parseFloat(
@@ -358,7 +359,7 @@ const getJsonObjectsFormatFromTableFormat_DataValues = ({
             ),
             indicator_name: rowData.indicator_name,
             orgUnitLevelsOrGroups: rowData.orgUnitLevelsOrGroups,
-            correspondingDatasetIDs: currentNumerator.dataSetID,
+            correspondingDatasetIDs: currentNumerator?.dataSetID,
             ou: rowData.ou,
         })
     }

--- a/src/components/annual-report/section2/section2abcCalculations.js
+++ b/src/components/annual-report/section2/section2abcCalculations.js
@@ -56,6 +56,11 @@ const calculateSections2a2b2c = ({
 
     for (const dx in formattedResponse) {
         const dxInfo = mappedConfiguration.dataElementsAndIndicators?.[dx]
+        // skip if dx is missing from configuration
+        if (!dxInfo) {
+            continue
+        }
+
         const thresholdValues = {
             extremeOutlier: dxInfo?.extremeOutlier || DEFAULT_EXTREME_OUTLIER,
             moderateOutlier:

--- a/src/components/annual-report/section2/section2dCalculations.js
+++ b/src/components/annual-report/section2/section2dCalculations.js
@@ -115,6 +115,11 @@ const calculateSection2d = ({
     for (const dx in overallResponse) {
         // retrieve info for dx
         const dxInfo = mappedConfiguration?.dataElementsAndIndicators?.[dx]
+        // skip if dx is missing from configuration
+        if (!dxInfo) {
+            continue
+        }
+
         if (!overallResponse[dx]?.[overallOrgUnit]?.[currentPeriodID]) {
             // skip if current period data is missing
             continue


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/RWDQA-59. Handles issues caused by data and reportParameters momentarily diverging when report is regenerated with new parameters. Note that the logic for data refetching will also be updated (https://dhis2.atlassian.net/browse/RWDQA-60) so that this should not be an issue, but the work here would prevent 

This PR:
- Section 1: adds in optional chaining to calculations/report. Missing values are prevented from causing errors.
- Section 2: skips over calculations when dx is missing from metadata
- Sections 3/4: does not make any changes. These sections do not need updates as they loop through `configurations` metadata and then will result in NaN values if the underlying values are missing from responses. Since these are consistent across groups, this should also not theoretically happen.

Note: I also considered updating the logic here to always use `configurations` as the "source of truth" to identify if we should display something, but this is a bit more complicated and seems (based on our discussion last week) to be inconsistent with what analytics generally does (/what the old app is doing). For Sections 3/4, we need to rely on `configurations` information, but for the other ones, we can base the report off of the values in the responses.