### PR TITLE
fix: forecast values/non-ou comparison [RWDQA-44]

### DIFF
--- a/src/components/annual-report/section1/section1Calculations.js
+++ b/src/components/annual-report/section1/section1Calculations.js
@@ -1,3 +1,4 @@
+import { getForecastValue, getMean } from '../utils/mathService.js'
 import { convertAnalyticsResponseToObject, getVal } from '../utils/utils.js'
 
 // gets a list of retions in which the reporting rate score was lower than the threshold
@@ -20,20 +21,16 @@ const getRegionsWithLowScoreForConsistencyOfDataset = ({
     overallDataset,
     regions,
     period,
+    periodsIDs,
 }) => {
     // calculate the boundaries (range) with this overall score and threshold
-    const leftBoundary =
-        Math.round(
-            overallDataset.score * (1 - overallDataset.threshold / 100) * 100
-        ) / 100
-    const rightBoundary =
-        Math.round(
-            overallDataset.score * (1 + overallDataset.threshold / 100) * 100
-        ) / 100
+    const { trend, comparisonFromConfig } = overallDataset
 
-    const years = Object.keys(
-        reporting_rate_by_org_unit_level_formatted[datasetID]
-    )
+    const comparisonBase =
+        comparisonFromConfig === 'ou' ? overallDataset.score : 1
+    const leftBoundary = comparisonBase * (1 - overallDataset.threshold / 100)
+    const rightBoundary = comparisonBase * (1 + overallDataset.threshold / 100)
+
     const currentDataset = reporting_rate_by_org_unit_level_formatted[datasetID]
 
     /* PROCEDURES  :
@@ -68,25 +65,43 @@ const getRegionsWithLowScoreForConsistencyOfDataset = ({
     */
     const regionsWithDivergentScore = []
     regions.forEach((region) => {
-        let regionScore = null
-        years.forEach((year) => {
-            if (year !== period) {
-                const score = parseFloat(
-                    currentDataset[year].find((item) => item.ou === region.id)
-                        .score
-                )
-                regionScore += score
-            }
-        })
-        // perform calculations to decide whether a region is between the boundaries
-        const chosenPeriodScore = parseFloat(
-            currentDataset[period].find((item) => item.ou === region.id).score
+        let reference = 0
+        const comparisonPeriods = periodsIDs.filter((pe) => pe !== period)
+
+        const points = comparisonPeriods
+            .map((year, index) => {
+                return [
+                    comparisonPeriods.length - index - 1,
+                    parseFloat(
+                        currentDataset?.[year]?.find(
+                            (item) => item.ou === region.id
+                        )?.score
+                    ),
+                ]
+            })
+            .filter((point) => !isNaN(point[1]))
+
+        if (trend === 'constant') {
+            // reference is average for 'constant' trend
+            const yearValues = points.map((point) => point[1])
+            reference = getMean(yearValues)
+        } else {
+            // otherwise the reference is the forecast value
+            reference = Math.max(
+                getForecastValue({
+                    pointsArray: points,
+                    forecastX: comparisonPeriods.length,
+                }),
+                0
+            )
+        }
+
+        const currentYearValue = parseFloat(
+            currentDataset?.[period]?.find((item) => item.ou === region.id)
+                ?.score
         )
 
-        // devide by number of the previous regions which is (years - 1)
-        // TODO: remember to cater for devide by zero or decide whether the user is allowed to choose 0 comparison years
-        const finalRegionScore =
-            (chosenPeriodScore / (regionScore / (years.length - 1))) * 100
+        const finalRegionScore = (currentYearValue / reference) * 100
         if (
             finalRegionScore < leftBoundary ||
             finalRegionScore > rightBoundary
@@ -187,6 +202,7 @@ const getJsonObjectsFormatFromTableFormat = ({
                     currentDataSetId
                 ].consistencyThreshold
             rowData['trend'] = trend
+            rowData.comparisonFromConfig = comparison
 
             if (comparison === 'th' && trend === 'constant') {
                 rowData['comparison'] = 'Current vs average'
@@ -224,6 +240,7 @@ const getJsonObjectsFormatFromTableFormat = ({
                 dataset_name: rowData.dataset_name,
                 trend: rowData.trend,
                 comparison: rowData.comparison,
+                comparisonFromConfig: rowData.comparisonFromConfig,
                 threshold: rowData.threshold,
                 score: rowData.value,
                 orgUnitLevelsOrGroups: rowData.orgUnitLevelsOrGroups,
@@ -255,29 +272,52 @@ const filterDataByProvidedPeriod = (dataToFilter, period) => {
     return filteredData
 }
 
-const filterDataByProvidedPeriodConsistency = (dataToFilter, period) => {
+const filterDataByProvidedPeriodConsistency = (
+    dataToFilter,
+    period,
+    periodsIDs
+) => {
     // Restructure the JSON object
     const restructuredObject = {}
 
     for (const datasetId in dataToFilter) {
         const dataset = dataToFilter[datasetId]
-        const years = Object.keys(dataset)
+        const trend = dataset?.[period]?.[0]?.trend ?? 'constant'
 
-        // Initialize the total score for different periods
-        let totalScore = 0
+        // Initialize the reference value for different periods
+        let reference = 0
 
-        // Loop through the years exclude the current one
-        years.forEach((year) => {
-            if (year !== period) {
-                const score = parseFloat(dataset[year][0].score)
-                totalScore += score
-            }
-        })
+        // get points for each year (index and value, filtering out null values (including current year))
+        const comparisonPeriods = periodsIDs.filter((pe) => pe !== period)
+        const points = comparisonPeriods
+            .map((year, index) => {
+                return [
+                    comparisonPeriods.length - index - 1,
+                    parseFloat(dataset[year]?.[0]?.score),
+                ]
+            })
+            .filter((point) => !isNaN(point[1]))
+
+        if (trend === 'constant') {
+            // reference is average for 'constant' trend
+            const yearValues = points.map((point) => point[1])
+            reference = getMean(yearValues)
+        } else {
+            // otherwise the reference is the forecast value
+            reference = Math.max(
+                getForecastValue({
+                    pointsArray: points,
+                    forecastX: comparisonPeriods.length,
+                }),
+                0
+            )
+        }
+
+        const currentYearValue = dataset?.[period]?.[0]?.score
 
         // the function to calculate the score using the previous chosen years
         // TODO: remember to cater for devide by zero or decide whether the user is allowed to choose 0 comparison years
-        const theScore =
-            (dataset[period][0].score / (totalScore / (years.length - 1))) * 100
+        const theScore = (currentYearValue / reference) * 100
 
         // Create the currentYear object
         const currentYear = [
@@ -575,6 +615,7 @@ const getConsistencyOfDatasetCompletenessData = ({
     mappedConfigurations,
     period,
     calculatingFor,
+    periodsIDs,
 }) => {
     const reporting_rate_over_all_org_units_formatted =
         getJsonObjectsFormatFromTableFormat({
@@ -593,7 +634,8 @@ const getConsistencyOfDatasetCompletenessData = ({
     // filtering data (overall) by provided period
     const filteredData_overall = filterDataByProvidedPeriodConsistency(
         reporting_rate_over_all_org_units_formatted,
-        period
+        period,
+        periodsIDs
     )
 
     // get available regions to calculate for
@@ -613,6 +655,7 @@ const getConsistencyOfDatasetCompletenessData = ({
                 overallDataset: dataset[0],
                 regions: regions,
                 period: period,
+                periodsIDs,
             })
 
         // Calculate "divergentRegionsCount" and "divergentRegionsPercent"
@@ -727,6 +770,7 @@ export const calculateSection1 = ({
             mappedConfigurations: mappedConfigurations,
             period: period,
             calculatingFor: 'section1D',
+            periodsIDs,
         }), // list of objects for Consistency of dataset completeness over time
         chartInfo: getSection1dChartInfo({
             allOrgUnitsData:


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/RWDQA-44

This PR:
- adds calculations for Increasing/Decreasing trend types in section 1d (note that forecast values are floored at zero in old app https://github.com/dhis2/who-data-quality-app/blob/c3fac5237e540e3eac5640c3995ec14687e23ea8/src/appCore/dqAnalysisConsistency.js#L474 and this is replicated here)
- adds the `th` comparison (that is the comparison where we do not compare against the overall OU comparison)
- does some minor clean up (e.g. use `getMean` from mathService for calculating average, changes some variable names to make them a bit clearer when the constant/non-constant calculation distinction was added)