### PR TITLE
fix: data element operands [RWDQA-78]

### DIFF
--- a/src/components/annual-report/ReportData.js
+++ b/src/components/annual-report/ReportData.js
@@ -24,13 +24,19 @@ export const ReportData = ({ reportParameters }) => {
         return null
     }
 
+    const isSectionOneEmpty =
+        !Object.keys(
+            reportParameters.mappedConfiguration.dataElementsAndIndicators
+        ).length ||
+        !Object.keys(reportParameters.mappedConfiguration.dataSets).length
+
     return (
         <div className={styles.reportContainer}>
             <SectionLayout title="Domain 1 - Completeness of Reporting">
-                {reportParameters.dataElements?.length > 0 ? (
-                    <SectionOne reportParameters={reportParameters} />
-                ) : (
+                {isSectionOneEmpty ? (
                     <NoDataInfoBox subsection={false} />
+                ) : (
+                    <SectionOne reportParameters={reportParameters} />
                 )}
             </SectionLayout>
             <SectionLayout title="Domain 2 - Internal Consistency of Reported Data">

--- a/src/components/annual-report/section1/section1Calculations.js
+++ b/src/components/annual-report/section1/section1Calculations.js
@@ -1,5 +1,13 @@
-import { getForecastValue, getMean } from '../utils/mathService.js'
-import { convertAnalyticsResponseToObject, getVal } from '../utils/utils.js'
+import {
+    getForecastValue,
+    getMean,
+    getRoundedValue,
+} from '../utils/mathService.js'
+import {
+    convertAnalyticsResponseToObject,
+    getVal,
+    getValCO,
+} from '../utils/utils.js'
 
 // gets a list of retions in which the reporting rate score was lower than the threshold
 const getRegionsWithLowScore = (filterd_datasets, key) => {
@@ -112,49 +120,6 @@ const getRegionsWithLowScoreForConsistencyOfDataset = ({
     return regionsWithDivergentScore
 }
 
-const getRegionsWithLowScoreCompletenessOfIndicator = (
-    dataValuesByLevel,
-    expectedReportsByLevel,
-    indicatorObjects
-) => {
-    if (!indicatorObjects) {
-        return [] // Return an empty array if the key is not found
-    }
-
-    // TODO: variables naming in this function could be improved
-    const regionsWithLowScore = []
-    indicatorObjects.forEach((object) => {
-        const correspondingDatasetIDs = object.correspondingDatasetIDs
-        const ou = object.ou
-
-        let subOrgUnitScore = 0
-
-        for (const correspondingDatasetID of correspondingDatasetIDs) {
-            if (!expectedReportsByLevel[correspondingDatasetID]) {
-                console.log(
-                    `No dataset found for ID: ${correspondingDatasetID}`
-                )
-            }
-            const matchingDataset = expectedReportsByLevel[
-                correspondingDatasetID
-            ].find((dataset) => dataset.ou === ou)
-            if (matchingDataset) {
-                subOrgUnitScore += matchingDataset.score ?? 0
-            } else {
-                ;`No matching dataset ${correspondingDatasetID} found for SubOrgUnit: ${object.orgUnitLevelsOrGroups}`
-            }
-        }
-        const reportingPercentage =
-            (object.actualValues / subOrgUnitScore) * 100
-
-        if (reportingPercentage < object.threshold) {
-            regionsWithLowScore.push(object.orgUnitLevelsOrGroups)
-        }
-    })
-
-    return regionsWithLowScore
-}
-
 // returns a JSON formatted object from the table-like format from analytics
 const getJsonObjectsFormatFromTableFormat = ({
     headers,
@@ -251,17 +216,6 @@ const getJsonObjectsFormatFromTableFormat = ({
     return restructuredData
 }
 
-// Function to find the numerator
-const findNumerator = (numerators, dataElementID) => {
-    return (
-        numerators[dataElementID] ||
-        Object.values(numerators).find((item) => {
-            const parts = item.dataElementOperandID.split('.')
-            return parts.length > 1 && parts[0] === dataElementID
-        })
-    )
-}
-
 const filterDataByProvidedPeriod = (dataToFilter, period) => {
     const filteredData = {}
     for (const dx in dataToFilter) {
@@ -333,78 +287,6 @@ const filterDataByProvidedPeriodConsistency = (
     return restructuredObject
 }
 
-// returns a JSON formatted object from the table-like format from analytics
-const getJsonObjectsFormatFromTableFormat_DataValues = ({
-    headers,
-    rows,
-    metaData,
-    mappedConfigurations,
-    expected_overall,
-    period,
-}) => {
-    const restructuredData = {}
-
-    for (const row of rows) {
-        const rowData = {}
-        const ouHeaderIndex = headers.map((header) => header.name).indexOf('ou')
-        const dsNameIndex = headers.map((header) => header.name).indexOf('dx')
-
-        for (let i = 0; i < headers.length; i++) {
-            const header = headers[i]
-            const columnName = header.name
-            const columnValue = row[i]
-            // Add the key-value pair to the row data object
-            rowData[columnName] = columnValue
-        }
-
-        rowData['orgUnitLevelsOrGroups'] =
-            metaData.items[row[ouHeaderIndex]].name
-        rowData['indicator_name'] = metaData.items[row[dsNameIndex]].name
-
-        const dx = rowData.dx.split('.')[0]
-        const pe = rowData.pe
-
-        const currentNumerator = findNumerator(
-            mappedConfigurations.dataElementsAndIndicators,
-            dx
-        )
-
-        if (!restructuredData[dx]) {
-            restructuredData[dx] = {}
-        }
-
-        if (!restructuredData[dx][pe]) {
-            restructuredData[dx][pe] = []
-        }
-        // const expectedValues = getExpectedValues(currentNumerator.dataSetID, expected_overall, period )
-        const expectedValues = currentNumerator.dataSetID.reduce(
-            (totalExpected, dsUID) => {
-                totalExpected += Number(
-                    expected_overall?.[dsUID]?.[period]?.[0]?.score ?? 0
-                )
-                return totalExpected
-            },
-            0
-        )
-
-        //TODO: most values here are not needed while working on count_of_data_values_by_org_unit_level, will find a suitable condition to ignore them
-        //construct the object for each
-        restructuredData[dx][pe].push({
-            threshold: currentNumerator.missing, // get this from missing value calculate these above in rows
-            expectedValues: parseFloat(expectedValues),
-            actualValues: parseInt(rowData.value),
-            overallScore: parseFloat(
-                ((rowData.value / expectedValues) * 100).toFixed(1)
-            ),
-            indicator_name: rowData.indicator_name,
-            orgUnitLevelsOrGroups: rowData.orgUnitLevelsOrGroups,
-            correspondingDatasetIDs: currentNumerator.dataSetID,
-            ou: rowData.ou,
-        })
-    }
-    return restructuredData
-}
-
 const getFacilityReportingData = ({
     allOrgUnitsData,
     byOrgUnitLevelData,
@@ -466,143 +348,6 @@ const getFacilityReportingData = ({
         })
     }
     const flattenedData = Object.values(filteredData_overall).map(
-        (item) => item[0]
-    )
-    return flattenedData
-}
-
-// get the data for section 1C
-const getCompletenessOfIndicatorData = ({
-    expected_reports_over_all_org_units,
-    expected_reports_by_org_unit_level,
-    count_of_data_values_over_all_org_units,
-    count_of_data_values_by_org_unit_level,
-    mappedConfigurations,
-    period,
-}) => {
-    // exptected reports overll org units
-    const expected_reports_over_all_org_units_formatted =
-        getJsonObjectsFormatFromTableFormat({
-            ...expected_reports_over_all_org_units,
-            mappedConfigurations: mappedConfigurations,
-            calculatingFor: 'section1C',
-        })
-
-    // exptected reports by org unit level
-    const expected_reports_by_org_unit_level_formatted =
-        getJsonObjectsFormatFromTableFormat({
-            ...expected_reports_by_org_unit_level,
-            mappedConfigurations: mappedConfigurations,
-            calculatingFor: 'section1C',
-        })
-
-    // data values
-    const count_of_data_values_over_all_org_units_formatted =
-        getJsonObjectsFormatFromTableFormat_DataValues({
-            ...count_of_data_values_over_all_org_units,
-            mappedConfigurations: mappedConfigurations,
-            expected_overall: expected_reports_over_all_org_units_formatted,
-            period: period,
-        })
-
-    // data values by org unit levels
-    // TODO: for this the expected_reports_over_all_org_units_formatted is not neccessary improve this (will find a way to remove it without harming the code's working)
-    const count_of_data_values_by_org_unit_level_formatted =
-        getJsonObjectsFormatFromTableFormat_DataValues({
-            ...count_of_data_values_by_org_unit_level,
-            mappedConfigurations: mappedConfigurations,
-            expected_overall: expected_reports_over_all_org_units_formatted,
-            period: period,
-        })
-
-    // filtering data (levels) by provided period
-    const filteredCountOfDataValues = filterDataByProvidedPeriod(
-        count_of_data_values_over_all_org_units_formatted,
-        period
-    )
-
-    const filteredExpectedReportsByOrgUnitLevel = filterDataByProvidedPeriod(
-        expected_reports_by_org_unit_level_formatted,
-        period
-    )
-
-    const filteredCountOfDataValuesByOrgUnitLevel = filterDataByProvidedPeriod(
-        count_of_data_values_by_org_unit_level_formatted,
-        period
-    )
-
-    for (const key in filteredCountOfDataValues) {
-        const indicatorObjectsByLevels =
-            filteredCountOfDataValuesByOrgUnitLevel[key]
-        const currentOverAllIndicator = filteredCountOfDataValues[key]
-
-        /*
-            PROCEDURE:
-            here data used are from 
-                -count_of_data_values_by_org_unit_level
-                -expected_reports_by_org_unit_level
-            
-            loop through the list of data element count_of_data_values_by_org_unit_level (format these data first if necessary)
-            for each data element decide for a region in which it appears in
-            
-            %age is found by (count of a data elment for that region / expected report for that region ) *100
-            
-            ie: 
-
-            [
-                "YAAmrY2RPbZ",
-                "iQx6Edf0Xib",
-                "2022",
-                "807.0"
-            ],
-
-            here above, we have 807 reports for yaamr data element (pnc visi) for region iQx6Edf0Xib (region b)
-
-            to know what we expected, take that data elemtn id and search in configurations to find the dataset it corresponds to 
-            YAAmrY2RPbZ corresponds to YmRjo8j3F3M (datasetID)
-            the look into expected_reports_by_org_unit_level for this found dataset on the same perion iQx6Edf0Xib
-        
-            wer found: 
-            [
-                "YmRjo8j3F3M.EXPECTED_REPORTS",
-                "iQx6Edf0Xib",
-                "2022",
-                "1224.0"
-            ],
-
-            from here we had 807 and we expected 1224
-            so (807/1224)*100 = 66%
-            this is below 90 so it gets added to the region with divergent scores
-            */
-
-        const regionsWithLowScore =
-            getRegionsWithLowScoreCompletenessOfIndicator(
-                filteredCountOfDataValuesByOrgUnitLevel,
-                filteredExpectedReportsByOrgUnitLevel,
-                indicatorObjectsByLevels
-            ).sort()
-        // console.log(`regions for ${key}: ${regionsWithLowScore}`)
-
-        // Calculate "divergentRegionsCount" and "divergentRegionsPercent"
-        const divergentRegionsCount = regionsWithLowScore.length
-        const totalRegionsCount = indicatorObjectsByLevels.length
-
-        // in case no region was under the threshold, the divergent % will remain zero
-        let divergentRegionsPercent = 0
-        if (totalRegionsCount > 0) {
-            divergentRegionsPercent =
-                (divergentRegionsCount / totalRegionsCount) * 100
-        }
-
-        // Add the new properties to the currentOverAllIndicator
-        currentOverAllIndicator.forEach((entry) => {
-            entry.divergentRegionsCount = divergentRegionsCount
-            entry.divergentRegionsPercent = divergentRegionsPercent
-            entry.orgUnitLevelsOrGroups = regionsWithLowScore
-        })
-    }
-
-    const flattenedData = Object.values(filteredCountOfDataValues).map(
         (item) => item[0]
     )
     return flattenedData
@@ -717,6 +462,132 @@ const getSection1dChartInfo = ({ allOrgUnitsData, periodsIDs, ou }) => {
     return chartInfo
 }
 
+const getExpectedValues = ({ numerator, response, pe, ou }) => {
+    return numerator.dataSetID.reduce((totalExpected, dsUID) => {
+        totalExpected += Number(
+            getVal({ response, dx: dsUID + '.EXPECTED_REPORTS', ou, pe }) ?? 0
+        )
+        return totalExpected
+    }, 0)
+}
+
+const getActualValue1C = ({ response, dx, co, pe, ou }) => {
+    // if the coc is undefined, assume that it is the system default COC
+
+    return getValCO({ response, dx, co, ou, pe })
+}
+
+const calculateSection1C = ({
+    expected_reports_over_all_org_units,
+    expected_reports_by_org_unit_level,
+    count_of_data_values_over_all_org_units,
+    count_of_data_values_by_org_unit_level,
+    mappedConfigurations,
+    period,
+    overallOrgUnit,
+    defaultCOC,
+}) => {
+    const section1C = []
+
+    // summarize expected reports
+    const overall_expected_reports = convertAnalyticsResponseToObject({
+        ...expected_reports_over_all_org_units,
+    })
+    const overall_counts = convertAnalyticsResponseToObject({
+        ...count_of_data_values_over_all_org_units,
+    })
+    const by_level_expected_reports = convertAnalyticsResponseToObject({
+        ...expected_reports_by_org_unit_level,
+    })
+    const by_level_counts = convertAnalyticsResponseToObject({
+        ...count_of_data_values_by_org_unit_level,
+    })
+
+    const metadata = [
+        expected_reports_over_all_org_units,
+        expected_reports_by_org_unit_level,
+        count_of_data_values_over_all_org_units,
+        count_of_data_values_by_org_unit_level,
+    ].reduce((allItems, resp) => {
+        return { ...allItems, ...resp.metaData.items }
+    }, {})
+
+    const subOrgUnits =
+        expected_reports_by_org_unit_level.metaData?.dimensions?.ou ?? []
+
+    for (const de in mappedConfigurations.dataElementsAndIndicators) {
+        //  get overall values
+        const numerator = mappedConfigurations.dataElementsAndIndicators[de]
+        const threshold = numerator.missing
+        const [deOperand = de, coOperand = defaultCOC] =
+            numerator.dataElementOperandID?.split('.')
+
+        const actualValues = getActualValue1C({
+            response: overall_counts,
+            pe: period,
+            ou: overallOrgUnit,
+            dx: deOperand,
+            co: coOperand,
+        })
+        const expectedValues = getExpectedValues({
+            response: overall_expected_reports,
+            pe: period,
+            ou: overallOrgUnit,
+            numerator,
+        })
+        const overallScore = getRoundedValue(
+            (actualValues / expectedValues) * 100,
+            1
+        )
+
+        // then calculate sub units
+        const divergentSubOrgUnits = []
+        for (const subOrgUnit of subOrgUnits) {
+            const actualSubOrgUnit = getActualValue1C({
+                response: by_level_counts,
+                pe: period,
+                ou: subOrgUnit,
+                dx: deOperand,
+                co: coOperand,
+            })
+            const expectedSubOrgUnit = getExpectedValues({
+                response: by_level_expected_reports,
+                pe: period,
+                ou: subOrgUnit,
+                numerator,
+            })
+            const scoreSubOrgUnit = actualSubOrgUnit / expectedSubOrgUnit
+
+            if (scoreSubOrgUnit * 100 < threshold) {
+                divergentSubOrgUnits.push(subOrgUnit)
+            }
+        }
+
+        section1C.push({
+            threshold,
+            expectedValues,
+            actualValues,
+            overallScore,
+            indicator_name: metadata[deOperand]?.name,
+            orgUnitLevelsOrGroups: divergentSubOrgUnits
+                .map((ouID) => metadata[ouID]?.name)
+                .sort(),
+            divergentRegionsCount: divergentSubOrgUnits.length,
+            divergentRegionsPercent: subOrgUnits.length
+                ? getRoundedValue(
+                      (divergentSubOrgUnits.length / subOrgUnits.length) * 100,
+                      1
+                  )
+                : 0,
+        })
+    }
+
+    section1C.sort((a, b) =>
+        a?.indicator_name?.localeCompare(b?.indicator_name)
+    )
+    return section1C
+}
+
 // function to structure analytics responses into different report sections as json objects using mapped configurations and chosen period
 export const calculateSection1 = ({
     reportQueryResponse,
@@ -724,6 +595,7 @@ export const calculateSection1 = ({
     period,
     periodsIDs,
     overallOrgUnit,
+    defaultCOC,
 }) => {
     if (!reportQueryResponse || !mappedConfigurations) {
         return {}
@@ -747,8 +619,8 @@ export const calculateSection1 = ({
             mappedConfigurations: mappedConfigurations,
             period: period,
             calculatingFor: 'section1B',
-        }), // list of objects for every dataset selected (regarding completeness)
-        section1C: getCompletenessOfIndicatorData({
+        }),
+        section1C: calculateSection1C({
             expected_reports_over_all_org_units:
                 reportQueryResponse.expected_reports_over_all_org_units,
             expected_reports_by_org_unit_level:
@@ -757,10 +629,10 @@ export const calculateSection1 = ({
                 reportQueryResponse.count_of_data_values_over_all_org_units,
             count_of_data_values_by_org_unit_level:
                 reportQueryResponse.count_of_data_values_by_org_unit_level,
-            reporting_timeliness_by_org_unit_level:
-                reportQueryResponse.reporting_timeliness_by_org_unit_level,
-            mappedConfigurations: mappedConfigurations,
+            mappedConfigurations,
             period: period,
+            overallOrgUnit,
+            defaultCOC,
         }),
         section1D: getConsistencyOfDatasetCompletenessData({
             allOrgUnitsData:

--- a/src/components/annual-report/section1/section1Calculations.js
+++ b/src/components/annual-report/section1/section1Calculations.js
@@ -517,15 +517,15 @@ const calculateSection1C = ({
         //  get overall values
         const numerator = mappedConfigurations.dataElementsAndIndicators[de]
         const threshold = numerator.missing
-        const [deOperand = de, coOperand = defaultCOC] =
+        const [deID = de, cocID = defaultCOC] =
             numerator.dataElementOperandID?.split('.')
 
         const actualValues = getActualValue1C({
             response: overall_counts,
             pe: period,
             ou: overallOrgUnit,
-            dx: deOperand,
-            co: coOperand,
+            dx: deID,
+            co: cocID,
         })
         const expectedValues = getExpectedValues({
             response: overall_expected_reports,
@@ -545,8 +545,8 @@ const calculateSection1C = ({
                 response: by_level_counts,
                 pe: period,
                 ou: subOrgUnit,
-                dx: deOperand,
-                co: coOperand,
+                dx: deID,
+                co: cocID,
             })
             const expectedSubOrgUnit = getExpectedValues({
                 response: by_level_expected_reports,
@@ -566,9 +566,9 @@ const calculateSection1C = ({
             expectedValues,
             actualValues,
             overallScore,
-            indicator_name: `${metadata[deOperand]?.name} ${
-                coOperand && coOperand !== defaultCOC
-                    ? '(' + metadata[coOperand]?.name + ')'
+            indicator_name: `${metadata[deID]?.name} ${
+                cocID && cocID !== defaultCOC
+                    ? '(' + metadata[cocID]?.name + ')'
                     : ''
             }`,
             orgUnitLevelsOrGroups: divergentSubOrgUnits

--- a/src/components/annual-report/section1/section1Calculations.js
+++ b/src/components/annual-report/section1/section1Calculations.js
@@ -568,7 +568,11 @@ const calculateSection1C = ({
             expectedValues,
             actualValues,
             overallScore,
-            indicator_name: metadata[deOperand]?.name,
+            indicator_name: `${metadata[deOperand]?.name} ${
+                coOperand && coOperand !== defaultCOC
+                    ? '(' + metadata[coOperand]?.name + ')'
+                    : ''
+            }`,
             orgUnitLevelsOrGroups: divergentSubOrgUnits
                 .map((ouID) => metadata[ouID]?.name)
                 .sort(),

--- a/src/components/annual-report/section1/section1Calculations.js
+++ b/src/components/annual-report/section1/section1Calculations.js
@@ -472,8 +472,6 @@ const getExpectedValues = ({ numerator, response, pe, ou }) => {
 }
 
 const getActualValue1C = ({ response, dx, co, pe, ou }) => {
-    // if the coc is undefined, assume that it is the system default COC
-
     return getValCO({ response, dx, co, ou, pe })
 }
 

--- a/src/components/annual-report/section1/useSectionOneData.js
+++ b/src/components/annual-report/section1/useSectionOneData.js
@@ -2,6 +2,17 @@ import { useDataEngine } from '@dhis2/app-runtime'
 import { useCallback, useState } from 'react'
 import { calculateSection1 } from './section1Calculations.js'
 
+const defaultCOCQuery = {
+    defaultCategoryCombo: {
+        resource: 'categoryCombos',
+        params: {
+            fields: 'id,categoryOptionCombos[id]',
+            filters: 'isDefault:eq:true',
+            paging: false,
+        },
+    },
+}
+
 const reportQueries = {
     reporting_rate_over_all_org_units: {
         resource: 'analytics.json',
@@ -62,7 +73,7 @@ const reportQueries = {
         params: ({ dataElements, orgUnits, currentPeriod }) => ({
             dimension: `dx:${dataElements.join(';')},ou:${orgUnits.join(
                 ';'
-            )},pe:${currentPeriod}`,
+            )},pe:${currentPeriod},co`,
             aggregationType: 'COUNT',
         }),
     },
@@ -71,7 +82,7 @@ const reportQueries = {
         params: ({ dataElements, orgUnits, orgUnitLevel, currentPeriod }) => ({
             dimension: `dx:${dataElements.join(';')},ou:${
                 orgUnits.join(';') + ';' + orgUnitLevel
-            },pe:${currentPeriod}`,
+            },pe:${currentPeriod},co`,
             aggregationType: 'COUNT',
         }),
     },
@@ -88,9 +99,28 @@ export const useSectionOneData = () => {
         async ({ variables = {} }) => {
             // set to loading
             setLoading(true)
+            const dataElementsAndIndicators =
+                variables.mappedConfiguration?.dataElementsAndIndicators
+            const dataElements = Object.keys(dataElementsAndIndicators).map(
+                (de) =>
+                    dataElementsAndIndicators[de].dataElementOperandID.split(
+                        '.'
+                    )[0]
+            )
             try {
+                const defaultCOCResponse = await engine.query(defaultCOCQuery)
+                const defaultCOC =
+                    defaultCOCResponse.defaultCategoryCombo?.categoryCombos?.[0]
+                        ?.categoryOptionCombos?.[0]?.id
+
                 const overallData = await engine.query(reportQueries, {
-                    variables,
+                    variables: {
+                        ...variables,
+                        dataSets: Object.keys(
+                            variables.mappedConfiguration.dataSets
+                        ),
+                        dataElements,
+                    },
                 })
                 const consolidatedData = { ...overallData }
 
@@ -100,6 +130,7 @@ export const useSectionOneData = () => {
                     period: variables.currentPeriod,
                     periodsIDs: variables.periods,
                     overallOrgUnit: variables.orgUnits?.[0],
+                    defaultCOC,
                 })
 
                 setData(section1Data)

--- a/src/components/annual-report/section1/useSectionOneData.js
+++ b/src/components/annual-report/section1/useSectionOneData.js
@@ -108,12 +108,7 @@ export const useSectionOneData = () => {
                     )[0]
             )
             try {
-                const defaultCOCResponse = await engine.query(defaultCOCQuery)
-                const defaultCOC =
-                    defaultCOCResponse.defaultCategoryCombo?.categoryCombos?.[0]
-                        ?.categoryOptionCombos?.[0]?.id
-
-                const overallData = await engine.query(reportQueries, {
+                const overallDataQuery = engine.query(reportQueries, {
                     variables: {
                         ...variables,
                         dataSets: Object.keys(
@@ -122,6 +117,15 @@ export const useSectionOneData = () => {
                         dataElements,
                     },
                 })
+
+                const [defaultCOCResponse, overallData] = await Promise.all([
+                    engine.query(defaultCOCQuery),
+                    overallDataQuery,
+                ])
+                const defaultCOC =
+                    defaultCOCResponse.defaultCategoryCombo?.categoryCombos?.[0]
+                        ?.categoryOptionCombos?.[0]?.id
+
                 const consolidatedData = { ...overallData }
 
                 const section1Data = calculateSection1({
@@ -132,7 +136,6 @@ export const useSectionOneData = () => {
                     overallOrgUnit: variables.orgUnits?.[0],
                     defaultCOC,
                 })
-
                 setData(section1Data)
             } catch (e) {
                 console.error(e)

--- a/src/components/annual-report/section1/useSectionOneData.js
+++ b/src/components/annual-report/section1/useSectionOneData.js
@@ -7,7 +7,7 @@ const defaultCOCQuery = {
         resource: 'categoryCombos',
         params: {
             fields: 'id,categoryOptionCombos[id]',
-            filters: 'isDefault:eq:true',
+            filter: 'isDefault:eq:true',
             paging: false,
         },
     },

--- a/src/components/annual-report/section2/SectionTwo.js
+++ b/src/components/annual-report/section2/SectionTwo.js
@@ -279,6 +279,9 @@ export const SectionTwo = ({ reportParameters }) => {
         const variables = {
             ...reportParameters,
             currentPeriod: reportParameters.periods[0],
+            dataSets: Object.keys(
+                reportParameters.mappedConfiguration.dataSets
+            ),
         }
 
         refetch({ variables })

--- a/src/components/annual-report/section2/useSectionTwoData.js
+++ b/src/components/annual-report/section2/useSectionTwoData.js
@@ -181,7 +181,9 @@ export const useSectionTwoData = () => {
             })
 
             const validDataElementPeriodTypes = getValidDataElementPeriodTypes({
-                dataElements: variables.dataElements,
+                dataElements: Object.keys(
+                    variables.mappedConfiguration.dataElementsAndIndicators
+                ),
                 dataSetTypes: dataSetResponse?.dataSets?.dataSets,
                 mappedConfiguration: variables.mappedConfiguration,
             })

--- a/src/components/annual-report/utils/utils.js
+++ b/src/components/annual-report/utils/utils.js
@@ -1,5 +1,13 @@
 export const getVal = ({ response, dx, ou, pe }) => {
-    return response?.[dx]?.[ou]?.[pe]
+    const val = response?.[dx]?.[ou]?.[pe]
+    if (typeof val !== 'object') {
+        return val
+    }
+    return undefined
+}
+
+export const getValCO = ({ response, dx, ou, pe, co }) => {
+    return response?.[dx]?.[ou]?.[pe]?.[co]
 }
 
 export const sortArrayAfterIndex1 = (unsortedArray) => {
@@ -29,6 +37,7 @@ export const convertAnalyticsResponseToObject = ({ headers, rows }) => {
         const dx = rowData.dx
         const pe = rowData.pe
         const ou = rowData.ou
+        const co = rowData.co
 
         if (!restructuredData[dx]) {
             restructuredData[dx] = {}
@@ -38,8 +47,20 @@ export const convertAnalyticsResponseToObject = ({ headers, rows }) => {
             restructuredData[dx][ou] = {}
         }
 
-        if (!restructuredData[dx][ou][pe] && !isNaN(Number(rowData.value))) {
-            restructuredData[dx][ou][pe] = Number(rowData.value)
+        if (!restructuredData[dx][ou][pe]) {
+            if (co) {
+                restructuredData[dx][ou][pe] = {}
+            } else {
+                restructuredData[dx][ou][pe] = undefined // must be undefined to prevent calculation errors with null
+            }
+        }
+
+        if (!isNaN(Number(rowData.value))) {
+            if (co) {
+                restructuredData[dx][ou][pe][co] = Number(rowData.value)
+            } else {
+                restructuredData[dx][ou][pe] = Number(rowData.value)
+            }
         }
     }
     return restructuredData

--- a/src/components/report-parameter-selector/getReportParameters.js
+++ b/src/components/report-parameter-selector/getReportParameters.js
@@ -25,10 +25,6 @@ export const getReportParameters = ({
     )
 
     const reportParameters = {
-        dataSets: Object.keys(mappedConfiguration.dataSets),
-        dataElements: Object.keys(
-            mappedConfiguration.dataElementsAndIndicators
-        ),
         orgUnits: [orgUnitID],
         orgUnitLevel: `LEVEL-${orgUnitLevel}`,
         orgUnitLevelNumber: orgUnitLevel,
@@ -38,5 +34,6 @@ export const getReportParameters = ({
         periods,
         mappedConfiguration,
     }
+
     return reportParameters
 }

--- a/src/components/report-parameter-selector/getReportParameters.js
+++ b/src/components/report-parameter-selector/getReportParameters.js
@@ -34,6 +34,5 @@ export const getReportParameters = ({
         periods,
         mappedConfiguration,
     }
-
     return reportParameters
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -39,7 +39,8 @@ export const getConfigObjectsForAnalytics = (configurations, groupCode) => {
                 members.includes(numerator.code) &&
                 numerator.dataID &&
                 numerator.dataSetID &&
-                numerator.dataSetID.length
+                numerator.dataSetID.length &&
+                numerator.dataElementOperandID
             )
         })
         // and convert numerator dataSetID to an array of IDs if not already the case (backwards compatibility)


### PR DESCRIPTION
This PR adds handling for data element operands (see https://dhis2.atlassian.net/browse/RWDQA-78)

Here I'm assuming that all numerators will have a data element operand id (this seems to be required by the old app's UI). If that's not the case, the calculations could be modified slightly.

The configurations at https://demos.dhis2.org/dq/api/dataStore/dataQualityTool/settings have some dataElementOperandIDs where there is only an ID (i.e. not an `{deUID}.{cocUID}`), so I've also added handling in for retrieving the default COC and using that as the COC if the COC is missing from the data element operand id. I don't actually know why this occurs because the old app seems to sometimes saves a data element operand that is `{deUID}.{defaultCOCUID` and other times just saves `{deUID}`. This might be something to update based on how the numerator configuration gets implemented

In order to do these calculations, I've recalculated the calculations for Section 1C as this seemed easier to handle using some of the existing logic for extracting data values from responses.
