### PR TITLE
feat: add interpretations fields to report [RWDQA-15]

### DIFF
--- a/src/components/annual-report/common/InterpretationsField.js
+++ b/src/components/annual-report/common/InterpretationsField.js
@@ -1,0 +1,40 @@
+import { TextArea, Field } from '@dhis2/ui'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+import styles from './InterpretationsField.module.css'
+
+/**
+ * A reusable field to add after each report section. Has some print styles
+ * * If there's no text, it'll be hidden during print
+ * * If there is text, the textarea itself will be hidden and a styled div 
+ * will be shown because it looks better than the textarea
+ * * It expects to be added to `grid` layouts, which are used for side-by-side
+ * table and chart layouts in the report
+ */
+export const InterpretationsField = ({ className }) => {
+    const [value, setValue] = useState()
+    return (
+        <Field
+            label={'Interpretations'}
+            className={cx(
+                {
+                    // If there is no text, don't show this field at all during print
+                    [styles.hiddenInPrint]: value === '' || value === undefined,
+                },
+                styles.gridSpan2,
+                className
+            )}
+        >
+            <TextArea
+                className={styles.hiddenInPrint}
+                value={value}
+                rows={3}
+                onChange={({ value }) => setValue(value)}
+            />
+
+            <div className={styles.visibleInPrint}>{value}</div>
+        </Field>
+    )
+}
+InterpretationsField.propTypes = { className: PropTypes.string }

--- a/src/components/annual-report/common/InterpretationsField.module.css
+++ b/src/components/annual-report/common/InterpretationsField.module.css
@@ -1,0 +1,23 @@
+.gridSpan2 {
+    /* This is expected to be added to grids and span 2 columns */
+    grid-column-start: span 2;
+}
+
+.visibleInPrint {
+    display: none;
+}
+
+@media print {
+    .hiddenInPrint {
+        display: none !important; /* needs to compete with display: flex */
+    }
+
+    .visibleInPrint {
+        display: block;
+        /* mimic styles from textarea */
+        padding: 8px 12px;
+        border: 1px solid var(--colors-grey400);
+        font-size: 14px;
+        line-height: 17px;    
+    }
+}

--- a/src/components/annual-report/common/index.js
+++ b/src/components/annual-report/common/index.js
@@ -1,0 +1,2 @@
+export { InterpretationsField } from './InterpretationsField.js'
+export { NoDataInfoBox } from './NoDataWarning.js'

--- a/src/components/annual-report/section1/SectionOne.js
+++ b/src/components/annual-report/section1/SectionOne.js
@@ -2,6 +2,7 @@ import { TableBody, TableHead, TableRow, CircularLoader } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { Chart } from '../Chart.js'
+import { InterpretationsField } from '../common/index.js'
 import {
     ReportCell,
     ReportCellHead,
@@ -47,257 +48,300 @@ export const SectionOne = ({ reportParameters }) => {
         return (
             <>
                 {/* Section 1a */}
-                <ReportTable className={styles.subsection}>
-                    <TableHead>
-                        <ReportRowHead>
-                            <ReportCellHead colSpan="6">
-                                1a: Completeness of facility reporting
-                            </ReportCellHead>
-                        </ReportRowHead>
-                        <TableRow>
-                            <ReportCell
-                                colSpan="6"
-                                className={styles.subsectionSubtitle}
-                            >
-                                The percentage of expected reports that have
-                                been entered and completed.
-                            </ReportCell>
-                        </TableRow>
-                        <ReportRowHead>
-                            <ReportCellHead rowSpan="2">
-                                Data set
-                            </ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Quality threshold
-                            </ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Overall score
-                            </ReportCellHead>
-                            <ReportCellHead colSpan="3">
-                                Regions with divergent score
-                            </ReportCellHead>
-                        </ReportRowHead>
-                        <ReportRowHead>
-                            <ReportCellHead>Number</ReportCellHead>
-                            <ReportCellHead>Percentage</ReportCellHead>
-                            <ReportCellHead>Name</ReportCellHead>
-                        </ReportRowHead>
-                    </TableHead>
-
-                    <TableBody>
-                        {section1Data.section1A.map((dataset, key) => (
-                            <TableRow key={key}>
-                                <ReportCell>{dataset.dataset_name}</ReportCell>
-                                <ReportCell>{dataset.threshold}%</ReportCell>
-                                <ReportCell>{dataset.score}%</ReportCell>
-                                <ReportCell>
-                                    {dataset.divergentRegionsCount}
-                                </ReportCell>
-                                <ReportCell>
-                                    {dataset.divergentRegionsPercent}%
-                                </ReportCell>
-                                <ReportCell>
-                                    {dataset.orgUnitLevelsOrGroups.join(', ')}
+                <div className={styles.subsection}>
+                    <ReportTable>
+                        <TableHead>
+                            <ReportRowHead>
+                                <ReportCellHead colSpan="6">
+                                    1a: Completeness of facility reporting
+                                </ReportCellHead>
+                            </ReportRowHead>
+                            <TableRow>
+                                <ReportCell
+                                    colSpan="6"
+                                    className={styles.subsectionSubtitle}
+                                >
+                                    The percentage of expected reports that have
+                                    been entered and completed.
                                 </ReportCell>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </ReportTable>
+                            <ReportRowHead>
+                                <ReportCellHead rowSpan="2">
+                                    Data set
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Quality threshold
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Overall score
+                                </ReportCellHead>
+                                <ReportCellHead colSpan="3">
+                                    Regions with divergent score
+                                </ReportCellHead>
+                            </ReportRowHead>
+                            <ReportRowHead>
+                                <ReportCellHead>Number</ReportCellHead>
+                                <ReportCellHead>Percentage</ReportCellHead>
+                                <ReportCellHead>Name</ReportCellHead>
+                            </ReportRowHead>
+                        </TableHead>
+
+                        <TableBody>
+                            {section1Data.section1A.map((dataset, key) => (
+                                <TableRow key={key}>
+                                    <ReportCell>
+                                        {dataset.dataset_name}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.threshold}%
+                                    </ReportCell>
+                                    <ReportCell>{dataset.score}%</ReportCell>
+                                    <ReportCell>
+                                        {dataset.divergentRegionsCount}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.divergentRegionsPercent}%
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.orgUnitLevelsOrGroups.join(
+                                            ', '
+                                        )}
+                                    </ReportCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </ReportTable>
+                    <InterpretationsField className={styles.marginTop4} />
+                </div>
 
                 {/* Section 1b */}
-                <ReportTable className={styles.subsection} e>
-                    <TableHead>
-                        <ReportRowHead>
-                            <ReportCellHead colSpan="6">
-                                1b: Timeliness of facility reporting
-                            </ReportCellHead>
-                        </ReportRowHead>
-                        <TableRow>
-                            <ReportCell
-                                colSpan="6"
-                                className={styles.subsectionSubtitle}
-                            >
-                                The percentage of expected reports that have
-                                been entered and completed on time.
-                            </ReportCell>
-                        </TableRow>
-                        <ReportRowHead>
-                            <ReportCellHead rowSpan="2">
-                                Data set
-                            </ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Quality threshold
-                            </ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Overall score
-                            </ReportCellHead>
-                            <ReportCellHead colSpan="3">
-                                Regions with divergent score
-                            </ReportCellHead>
-                        </ReportRowHead>
-                        <ReportRowHead>
-                            <ReportCellHead>Number</ReportCellHead>
-                            <ReportCellHead>Percentage</ReportCellHead>
-                            <ReportCellHead>Name</ReportCellHead>
-                        </ReportRowHead>
-                    </TableHead>
-
-                    <TableBody>
-                        {section1Data.section1B.map((dataset, key) => (
-                            <TableRow key={key}>
-                                <ReportCell>{dataset.dataset_name}</ReportCell>
-                                <ReportCell>{dataset.threshold}%</ReportCell>
-                                <ReportCell>{dataset.score}%</ReportCell>
-                                <ReportCell>
-                                    {dataset.divergentRegionsCount}
-                                </ReportCell>
-                                <ReportCell>
-                                    {dataset.divergentRegionsPercent}%
-                                </ReportCell>
-                                <ReportCell>
-                                    {dataset.orgUnitLevelsOrGroups.join(', ')}
+                <div className={styles.subsection}>
+                    <ReportTable>
+                        <TableHead>
+                            <ReportRowHead>
+                                <ReportCellHead colSpan="6">
+                                    1b: Timeliness of facility reporting
+                                </ReportCellHead>
+                            </ReportRowHead>
+                            <TableRow>
+                                <ReportCell
+                                    colSpan="6"
+                                    className={styles.subsectionSubtitle}
+                                >
+                                    The percentage of expected reports that have
+                                    been entered and completed on time.
                                 </ReportCell>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </ReportTable>
+                            <ReportRowHead>
+                                <ReportCellHead rowSpan="2">
+                                    Data set
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Quality threshold
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Overall score
+                                </ReportCellHead>
+                                <ReportCellHead colSpan="3">
+                                    Regions with divergent score
+                                </ReportCellHead>
+                            </ReportRowHead>
+                            <ReportRowHead>
+                                <ReportCellHead>Number</ReportCellHead>
+                                <ReportCellHead>Percentage</ReportCellHead>
+                                <ReportCellHead>Name</ReportCellHead>
+                            </ReportRowHead>
+                        </TableHead>
+
+                        <TableBody>
+                            {section1Data.section1B.map((dataset, key) => (
+                                <TableRow key={key}>
+                                    <ReportCell>
+                                        {dataset.dataset_name}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.threshold}%
+                                    </ReportCell>
+                                    <ReportCell>{dataset.score}%</ReportCell>
+                                    <ReportCell>
+                                        {dataset.divergentRegionsCount}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.divergentRegionsPercent}%
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.orgUnitLevelsOrGroups.join(
+                                            ', '
+                                        )}
+                                    </ReportCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </ReportTable>
+                    <InterpretationsField className={styles.marginTop4} />
+                </div>
 
                 {/* Section 1c */}
-                <ReportTable className={styles.subsection}>
-                    <TableHead>
-                        <ReportRowHead>
-                            <ReportCellHead colSpan="8">
-                                1c: Completeness of indicator data
-                            </ReportCellHead>
-                        </ReportRowHead>
-                        <TableRow>
-                            <ReportCell
-                                colSpan="8"
-                                className={styles.subsectionSubtitle}
-                            >
-                                Reports where values are not missing. If zeros
-                                are not stored, zeros are counted as missing.
-                            </ReportCell>
-                        </TableRow>
-                        <ReportRowHead>
-                            <ReportCellHead rowSpan="2">
-                                Indicator
-                            </ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Quality threshold
-                            </ReportCellHead>
-                            <ReportCellHead colSpan="2">Values</ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Overall Score
-                            </ReportCellHead>
-                            <ReportCellHead colSpan="3">
-                                Regions with divergent score
-                            </ReportCellHead>
-                        </ReportRowHead>
-                        <ReportRowHead>
-                            <ReportCellHead>Expected</ReportCellHead>
-                            <ReportCellHead>Actual</ReportCellHead>
-                            <ReportCellHead>Number</ReportCellHead>
-                            <ReportCellHead>Percentage</ReportCellHead>
-                            <ReportCellHead>Name</ReportCellHead>
-                        </ReportRowHead>
-                    </TableHead>
-
-                    <TableBody>
-                        {section1Data.section1C.map((dataset, key) => (
-                            <TableRow key={key}>
-                                <ReportCell>
-                                    {dataset.indicator_name}
-                                </ReportCell>
-                                <ReportCell>{dataset.threshold}%</ReportCell>
-                                <ReportCell>
-                                    {dataset.expectedValues}
-                                </ReportCell>
-                                <ReportCell>{dataset.actualValues}</ReportCell>
-                                <ReportCell>{dataset.overallScore}%</ReportCell>
-                                <ReportCell>
-                                    {dataset.divergentRegionsCount}
-                                </ReportCell>
-                                <ReportCell>
-                                    {dataset.divergentRegionsPercent}%
-                                </ReportCell>
-                                <ReportCell>
-                                    {dataset.orgUnitLevelsOrGroups.join(', ')}
+                <div className={styles.subsection}>
+                    <ReportTable>
+                        <TableHead>
+                            <ReportRowHead>
+                                <ReportCellHead colSpan="8">
+                                    1c: Completeness of indicator data
+                                </ReportCellHead>
+                            </ReportRowHead>
+                            <TableRow>
+                                <ReportCell
+                                    colSpan="8"
+                                    className={styles.subsectionSubtitle}
+                                >
+                                    Reports where values are not missing. If
+                                    zeros are not stored, zeros are counted as
+                                    missing.
                                 </ReportCell>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </ReportTable>
+                            <ReportRowHead>
+                                <ReportCellHead rowSpan="2">
+                                    Indicator
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Quality threshold
+                                </ReportCellHead>
+                                <ReportCellHead colSpan="2">
+                                    Values
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Overall Score
+                                </ReportCellHead>
+                                <ReportCellHead colSpan="3">
+                                    Regions with divergent score
+                                </ReportCellHead>
+                            </ReportRowHead>
+                            <ReportRowHead>
+                                <ReportCellHead>Expected</ReportCellHead>
+                                <ReportCellHead>Actual</ReportCellHead>
+                                <ReportCellHead>Number</ReportCellHead>
+                                <ReportCellHead>Percentage</ReportCellHead>
+                                <ReportCellHead>Name</ReportCellHead>
+                            </ReportRowHead>
+                        </TableHead>
+
+                        <TableBody>
+                            {section1Data.section1C.map((dataset, key) => (
+                                <TableRow key={key}>
+                                    <ReportCell>
+                                        {dataset.indicator_name}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.threshold}%
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.expectedValues}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.actualValues}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.overallScore}%
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.divergentRegionsCount}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.divergentRegionsPercent}%
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.orgUnitLevelsOrGroups.join(
+                                            ', '
+                                        )}
+                                    </ReportCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </ReportTable>
+                    <InterpretationsField className={styles.marginTop4} />
+                </div>
 
                 {/* Section 1d */}
-                <ReportTable className={styles.subsection}>
-                    <TableHead>
-                        <ReportRowHead>
-                            <ReportCellHead colSpan="8">
-                                1d: Consistency of dataset completeness over
-                                time
-                            </ReportCellHead>
-                        </ReportRowHead>
-                        <TableRow>
-                            <ReportCell
-                                colSpan="8"
-                                className={styles.subsectionSubtitle}
-                            >
-                                Completeness of datasets in 2022 compared to
-                                previous 3 years.
-                            </ReportCell>
-                        </TableRow>
-                        <ReportRowHead>
-                            <ReportCellHead rowSpan="2">
-                                Data set
-                            </ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Expected Trend
-                            </ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Compare Region to
-                            </ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Quality threshold
-                            </ReportCellHead>
-                            <ReportCellHead rowSpan="2">
-                                Overall score
-                            </ReportCellHead>
-                            <ReportCellHead colSpan="3">
-                                Regions with divergent score
-                            </ReportCellHead>
-                        </ReportRowHead>
-                        <ReportRowHead>
-                            <ReportCellHead>Number</ReportCellHead>
-                            <ReportCellHead>Percentage</ReportCellHead>
-                            <ReportCellHead>Name</ReportCellHead>
-                        </ReportRowHead>
-                    </TableHead>
-
-                    <TableBody>
-                        {section1Data.section1D.map((dataset, key) => (
-                            <TableRow key={key}>
-                                <ReportCell>{dataset.dataset_name}</ReportCell>
-                                <ReportCell>
-                                    {dataset.trend[0].toUpperCase() +
-                                        dataset.trend.slice(1)}
-                                </ReportCell>
-                                <ReportCell>{dataset.comparison}</ReportCell>
-                                <ReportCell>± {dataset.threshold}%</ReportCell>
-                                <ReportCell>{dataset.score}%</ReportCell>
-                                <ReportCell>
-                                    {dataset.divergentRegionsCount}
-                                </ReportCell>
-                                <ReportCell>
-                                    {dataset.divergentRegionsPercent}%
-                                </ReportCell>
-                                <ReportCell>
-                                    {dataset.orgUnitLevelsOrGroups.join(', ')}
+                <div className={styles.subsection}>
+                    <ReportTable>
+                        <TableHead>
+                            <ReportRowHead>
+                                <ReportCellHead colSpan="8">
+                                    1d: Consistency of dataset completeness over
+                                    time
+                                </ReportCellHead>
+                            </ReportRowHead>
+                            <TableRow>
+                                <ReportCell
+                                    colSpan="8"
+                                    className={styles.subsectionSubtitle}
+                                >
+                                    Completeness of datasets in 2022 compared to
+                                    previous 3 years.
                                 </ReportCell>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </ReportTable>
+                            <ReportRowHead>
+                                <ReportCellHead rowSpan="2">
+                                    Data set
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Expected Trend
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Compare Region to
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Quality threshold
+                                </ReportCellHead>
+                                <ReportCellHead rowSpan="2">
+                                    Overall score
+                                </ReportCellHead>
+                                <ReportCellHead colSpan="3">
+                                    Regions with divergent score
+                                </ReportCellHead>
+                            </ReportRowHead>
+                            <ReportRowHead>
+                                <ReportCellHead>Number</ReportCellHead>
+                                <ReportCellHead>Percentage</ReportCellHead>
+                                <ReportCellHead>Name</ReportCellHead>
+                            </ReportRowHead>
+                        </TableHead>
+
+                        <TableBody>
+                            {section1Data.section1D.map((dataset, key) => (
+                                <TableRow key={key}>
+                                    <ReportCell>
+                                        {dataset.dataset_name}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.trend[0].toUpperCase() +
+                                            dataset.trend.slice(1)}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.comparison}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        ± {dataset.threshold}%
+                                    </ReportCell>
+                                    <ReportCell>{dataset.score}%</ReportCell>
+                                    <ReportCell>
+                                        {dataset.divergentRegionsCount}
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.divergentRegionsPercent}%
+                                    </ReportCell>
+                                    <ReportCell>
+                                        {dataset.orgUnitLevelsOrGroups.join(
+                                            ', '
+                                        )}
+                                    </ReportCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </ReportTable>
+                    <InterpretationsField className={styles.marginTop4} />
+                </div>
 
                 <Chart
                     sectionId={'section1'}

--- a/src/components/annual-report/section1/SectionOne.module.css
+++ b/src/components/annual-report/section1/SectionOne.module.css
@@ -2,6 +2,10 @@
     margin-bottom: 24px;
 }
 
+.marginTop4 {
+    margin-top: 4px;
+}
+
 .section1Chart {
     composes: subsection;
     border: 1px solid var(--colors-grey400);

--- a/src/components/annual-report/section2/SectionTwo.js
+++ b/src/components/annual-report/section2/SectionTwo.js
@@ -2,7 +2,7 @@ import { TableBody, TableHead, TableRow } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { Chart } from '../Chart.js'
-import { NoDataInfoBox } from '../common/NoDataWarning.js'
+import { InterpretationsField, NoDataInfoBox } from '../common/index.js'
 import {
     ReportCell,
     ReportCellHead,
@@ -74,7 +74,7 @@ const Sections2a2b2c = ({ title, subtitle, subsectionData }) => {
 
     return (
         <div className={styles.section2abcContainer}>
-            <ReportTable>
+            <ReportTable className={styles.marginBottom4}>
                 <TableHead>
                     <SubSectionLayout title={title} subtitle={subtitle} />
                     <ReportRowHead>
@@ -116,6 +116,7 @@ const Sections2a2b2c = ({ title, subtitle, subsectionData }) => {
                     ))}
                 </TableBody>
             </ReportTable>
+            <InterpretationsField />
         </div>
     )
 }
@@ -192,6 +193,7 @@ const Section2DBlock = ({ dataRow, index }) => (
                 className={styles.section2dScatterChart}
             />
         )}
+        <InterpretationsField />
     </div>
 )
 
@@ -292,6 +294,7 @@ const Section2EBlock = ({ dataRow, index }) => (
                 className={styles.section2eChart}
             />
         )}
+        <InterpretationsField />
     </div>
 )
 

--- a/src/components/annual-report/section3/SectionThree.js
+++ b/src/components/annual-report/section3/SectionThree.js
@@ -2,6 +2,7 @@ import { TableBody, TableHead, TableRow } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { Chart } from '../Chart.js'
+import { InterpretationsField } from '../common/index.js'
 import {
     ReportCell,
     ReportCellHead,
@@ -126,12 +127,15 @@ const Section3A = ({ title, subtitle, subsectionData }) => (
                                 )}
                             </TableBody>
                         </ReportTable>
+
                         <Chart
                             sectionId={'section3'}
                             chartId={`chart${index}`}
                             chartInfo={dataRow.chartInfo}
                             className={styles.section3Chart}
                         />
+
+                        <InterpretationsField />
                     </div>
                 )
             })}

--- a/src/components/annual-report/section4/SectionFour.js
+++ b/src/components/annual-report/section4/SectionFour.js
@@ -2,6 +2,7 @@ import { TableBody, TableHead, TableRow } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { Chart } from '../Chart.js'
+import { InterpretationsField } from '../common/index.js'
 import {
     ReportCell,
     ReportCellHead,
@@ -134,12 +135,15 @@ const Section4B = ({ title, subtitle, subsectionData }) => (
                                 </TableRow>
                             </TableBody>
                         </ReportTable>
+
                         <Chart
                             sectionId={'section4'}
                             chartId={`chart${index}`}
                             chartInfo={dataRow.chartInfo}
                             className={styles.section4bChart}
                         />
+
+                        <InterpretationsField />
                     </div>
                 )
             })}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/RWDQA-15

Made a simple component to drop in anywhere in the report, and added some basic styles to make it look good in print. I also thought it made sense to hide empty fields during printing.

Web page:
<img width="989" alt="interpretations-field" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/49666798/6778892e-db2b-409c-ae97-9312736fff36">

Print preview:
<img width="1220" alt="print-preview" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/49666798/092278a4-04be-45d1-8a0e-dd03ddec7240">


Here are some things I noticed we'll need to do when we do the rest of the print styles:
1. Hide the header bar and selector bar and other non-report UI
2. Be able to print the whole report -- for some reason, it can only print the visible page right now
3. Enable page breaks so tables aren't cut in half
4. Graphs need to be smaller