### PR TITLE
fix: correct org unit level names [RWDQA-72]

### DIFF
--- a/src/components/annual-report/section1/SectionOne.js
+++ b/src/components/annual-report/section1/SectionOne.js
@@ -74,7 +74,7 @@ export const SectionOne = ({ reportParameters }) => {
                                 Overall score
                             </ReportCellHead>
                             <ReportCellHead colSpan="3">
-                                Regions with divergent score
+                                {`${reportParameters.orgUnitLevelName}s with divergent score`}
                             </ReportCellHead>
                         </ReportRowHead>
                         <ReportRowHead>
@@ -132,7 +132,7 @@ export const SectionOne = ({ reportParameters }) => {
                                 Overall score
                             </ReportCellHead>
                             <ReportCellHead colSpan="3">
-                                Regions with divergent score
+                                {`${reportParameters.orgUnitLevelName}s with divergent score`}
                             </ReportCellHead>
                         </ReportRowHead>
                         <ReportRowHead>
@@ -191,7 +191,7 @@ export const SectionOne = ({ reportParameters }) => {
                                 Overall Score
                             </ReportCellHead>
                             <ReportCellHead colSpan="3">
-                                Regions with divergent score
+                                {`${reportParameters.orgUnitLevelName}s with divergent score`}
                             </ReportCellHead>
                         </ReportRowHead>
                         <ReportRowHead>
@@ -243,8 +243,12 @@ export const SectionOne = ({ reportParameters }) => {
                                 colSpan="8"
                                 className={styles.subsectionSubtitle}
                             >
-                                Completeness of datasets in 2022 compared to
-                                previous 3 years.
+                                {`Completeness of datasets in ${
+                                    reportParameters.periods[0].name
+                                } compared to
+                                previous ${
+                                    reportParameters.periods.length - 1
+                                } years.`}
                             </ReportCell>
                         </TableRow>
                         <ReportRowHead>
@@ -264,7 +268,7 @@ export const SectionOne = ({ reportParameters }) => {
                                 Overall score
                             </ReportCellHead>
                             <ReportCellHead colSpan="3">
-                                Regions with divergent score
+                                {`${reportParameters.orgUnitLevelName}s with divergent score`}
                             </ReportCellHead>
                         </ReportRowHead>
                         <ReportRowHead>

--- a/src/components/annual-report/section2/SectionTwo.js
+++ b/src/components/annual-report/section2/SectionTwo.js
@@ -15,23 +15,23 @@ import { useSectionTwoData } from './useSectionTwoData.js'
 const sectionInformation = {
     section2a: {
         title: '2a: Extreme outliers',
-        subtitle:
-            'Extreme outliers, using the standard method. Threshold denotes the number of standard deviations from the mean. Region are counted as divergent if they have one or more extreme outliers for an indicator.',
+        subtitle: ({ orgUnitLevelName }) =>
+            `Extreme outliers, using the standard method. Threshold denotes the number of standard deviations from the mean. ${orgUnitLevelName}s are counted as divergent if they have one or more extreme outliers for an indicator.`,
     },
     section2b: {
         title: '2b: Moderate outliers',
-        subtitle:
-            'Moderate outliers, using the standard method. Threshold denotes the number of standard deviations from the mean. Region are counted as divergent if they have two or more moderate outliers for an indicator.',
+        subtitle: ({ orgUnitLevelName }) =>
+            `Moderate outliers, using the standard method. Threshold denotes the number of standard deviations from the mean. ${orgUnitLevelName}s are counted as divergent if they have two or more moderate outliers for an indicator.`,
     },
     section2c: {
         title: '2c: Moderate outliers',
-        subtitle:
-            'Moderate outliers, based on median (modified Z score). Region are counted as divergent if they have two or more moderate outliers for an indicator.',
+        subtitle: ({ orgUnitLevelName }) =>
+            `Moderate outliers, based on median (modified Z score). ${orgUnitLevelName}s are counted as divergent if they have two or more moderate outliers for an indicator.`,
     },
     section2d: {
         title: '2d: Consistency of indicator values over time',
-        subtitle:
-            'Difference between the current year and either the average of the 3 preceding years (if expected trend is constant), or the forecasted value.',
+        subtitle: ({ numReferenceYears }) =>
+            `Difference between the current year and either the average of the ${numReferenceYears} preceding years (if expected trend is constant), or the forecasted value.`,
     },
     section2e: {
         title: '2e: Consistency between related indicators',
@@ -58,13 +58,23 @@ SubSectionLayout.propTypes = {
     title: PropTypes.string,
 }
 
-const Sections2a2b2c = ({ title, subtitle, subsectionData }) => {
+const Sections2a2b2c = ({
+    title,
+    subtitle,
+    subsectionData,
+    reportParameters: { orgUnitLevelName },
+}) => {
+    const formattedSubtitle = subtitle({ orgUnitLevelName })
+
     if (subsectionData.length === 0) {
         return (
             <div className={styles.section2abcContainer}>
                 <ReportTable>
                     <TableHead>
-                        <SubSectionLayout title={title} subtitle={subtitle} />
+                        <SubSectionLayout
+                            title={title}
+                            subtitle={formattedSubtitle}
+                        />
                     </TableHead>
                 </ReportTable>
                 <NoDataInfoBox subsection={true} />
@@ -76,7 +86,10 @@ const Sections2a2b2c = ({ title, subtitle, subsectionData }) => {
         <div className={styles.section2abcContainer}>
             <ReportTable>
                 <TableHead>
-                    <SubSectionLayout title={title} subtitle={subtitle} />
+                    <SubSectionLayout
+                        title={title}
+                        subtitle={formattedSubtitle}
+                    />
                     <ReportRowHead>
                         <ReportCellHead rowSpan="2" width="200">
                             Indicator
@@ -88,7 +101,7 @@ const Sections2a2b2c = ({ title, subtitle, subsectionData }) => {
                             Overall score
                         </ReportCellHead>
                         <ReportCellHead colSpan="3">
-                            Region with divergent score
+                            {`${orgUnitLevelName}s with divergent score`}
                         </ReportCellHead>
                     </ReportRowHead>
                     <ReportRowHead>
@@ -120,12 +133,17 @@ const Sections2a2b2c = ({ title, subtitle, subsectionData }) => {
     )
 }
 Sections2a2b2c.propTypes = {
+    reportParameters: PropTypes.object,
     subsectionData: PropTypes.array,
-    subtitle: PropTypes.string,
+    subtitle: PropTypes.func,
     title: PropTypes.string,
 }
 
-const Section2DBlock = ({ dataRow, index }) => (
+const Section2DBlock = ({
+    dataRow,
+    index,
+    reportParameters: { orgUnitLevelName },
+}) => (
     <div className={styles.section2dGrid}>
         <ReportTable className={styles.section2dTable}>
             <TableHead>
@@ -155,7 +173,7 @@ const Section2DBlock = ({ dataRow, index }) => (
                 </TableRow>
                 <TableRow>
                     <ReportCell>
-                        Number of Region with divergent score
+                        {`Number of ${orgUnitLevelName}s with divergent score`}
                     </ReportCell>
                     <ReportCell>
                         {dataRow.divergentSubOrgUnits?.number}
@@ -163,7 +181,7 @@ const Section2DBlock = ({ dataRow, index }) => (
                 </TableRow>
                 <TableRow>
                     <ReportCell>
-                        Percent of Region with divergent score
+                        {`Percent of ${orgUnitLevelName}s with divergent score`}
                     </ReportCell>
                     <ReportCell>
                         {dataRow.divergentSubOrgUnits?.percent}%
@@ -198,13 +216,19 @@ const Section2DBlock = ({ dataRow, index }) => (
 Section2DBlock.propTypes = {
     dataRow: PropTypes.object,
     index: PropTypes.number,
+    reportParameters: PropTypes.object,
 }
 
-const Section2D = ({ title, subtitle, subsectionData }) => (
+const Section2D = ({ title, subtitle, subsectionData, reportParameters }) => (
     <>
         <ReportTable className={styles.marginBottom4}>
             <TableHead>
-                <SubSectionLayout title={title} subtitle={subtitle} />
+                <SubSectionLayout
+                    title={title}
+                    subtitle={subtitle({
+                        numReferenceYears: reportParameters.periods.length - 1,
+                    })}
+                />
             </TableHead>
         </ReportTable>
         {subsectionData.length === 0 && <NoDataInfoBox subsection={true} />}
@@ -213,18 +237,24 @@ const Section2D = ({ title, subtitle, subsectionData }) => (
                 key={dataRow.name}
                 dataRow={dataRow}
                 index={index}
+                reportParameters={reportParameters}
             />
         ))}
     </>
 )
 
 Section2D.propTypes = {
+    reportParameters: PropTypes.object,
     subsectionData: PropTypes.array,
-    subtitle: PropTypes.string,
+    subtitle: PropTypes.func,
     title: PropTypes.string,
 }
 
-const Section2EBlock = ({ dataRow, index }) => (
+const Section2EBlock = ({
+    dataRow,
+    index,
+    reportParameters: { orgUnitLevelName },
+}) => (
     <div className={styles.section2eGrid}>
         <ReportTable>
             <TableHead>
@@ -259,7 +289,7 @@ const Section2EBlock = ({ dataRow, index }) => (
                 </TableRow>
                 <TableRow>
                     <ReportCell>
-                        Number of Region with divergent score
+                        {`Number of ${orgUnitLevelName}s with divergent score`}
                     </ReportCell>
                     <ReportCell>
                         {dataRow.divergentSubOrgUnits?.number}
@@ -267,7 +297,7 @@ const Section2EBlock = ({ dataRow, index }) => (
                 </TableRow>
                 <TableRow>
                     <ReportCell>
-                        Percent of Region with divergent score
+                        {`Percent of ${orgUnitLevelName}s with divergent score`}
                     </ReportCell>
                     <ReportCell>
                         {dataRow.divergentSubOrgUnits?.percentage}%
@@ -298,9 +328,10 @@ const Section2EBlock = ({ dataRow, index }) => (
 Section2EBlock.propTypes = {
     dataRow: PropTypes.object,
     index: PropTypes.number,
+    reportParameters: PropTypes.object,
 }
 
-const Section2E = ({ title, subtitle, subsectionData }) => (
+const Section2E = ({ title, subtitle, subsectionData, reportParameters }) => (
     <>
         <ReportTable className={styles.marginBottom4}>
             <TableHead>
@@ -313,12 +344,14 @@ const Section2E = ({ title, subtitle, subsectionData }) => (
                 key={dataRow.title}
                 dataRow={dataRow}
                 index={index}
+                reportParameters={reportParameters}
             />
         ))}
     </>
 )
 
 Section2E.propTypes = {
+    reportParameters: PropTypes.object,
     subsectionData: PropTypes.array,
     subtitle: PropTypes.string,
     title: PropTypes.string,
@@ -373,26 +406,31 @@ export const SectionTwo = ({ reportParameters }) => {
                     title={sectionInformation.section2a.title}
                     subtitle={sectionInformation.section2a.subtitle}
                     subsectionData={section2Data.section2a}
+                    reportParameters={reportParameters}
                 />
                 <Sections2a2b2c
                     title={sectionInformation.section2b.title}
                     subtitle={sectionInformation.section2b.subtitle}
                     subsectionData={section2Data.section2b}
+                    reportParameters={reportParameters}
                 />
                 <Sections2a2b2c
                     title={sectionInformation.section2c.title}
                     subtitle={sectionInformation.section2c.subtitle}
                     subsectionData={section2Data.section2c}
+                    reportParameters={reportParameters}
                 />
                 <Section2D
                     title={sectionInformation.section2d.title}
                     subtitle={sectionInformation.section2d.subtitle}
                     subsectionData={section2Data.section2d}
+                    reportParameters={reportParameters}
                 />
                 <Section2E
                     title={sectionInformation.section2e.title}
                     subtitle={sectionInformation.section2e.subtitle}
                     subsectionData={section2Data.section2e}
+                    reportParameters={reportParameters}
                 />
             </>
         )

--- a/src/components/annual-report/section3/SectionThree.js
+++ b/src/components/annual-report/section3/SectionThree.js
@@ -41,7 +41,12 @@ SubSectionLayout.propTypes = {
     title: PropTypes.string,
 }
 
-const Section3A = ({ title, subtitle, subsectionData }) => (
+const Section3A = ({
+    title,
+    subtitle,
+    subsectionData,
+    reportParameters: { orgUnitLevelName },
+}) => (
     <>
         <ReportTable className={styles.marginBottom4}>
             <TableHead>
@@ -88,7 +93,7 @@ const Section3A = ({ title, subtitle, subsectionData }) => (
                                 </TableRow>
                                 <TableRow>
                                     <ReportCell>
-                                        Number of Region with divergent score
+                                        {`Number of ${orgUnitLevelName}s with divergent score`}
                                     </ReportCell>
                                     <ReportCell>
                                         {isNotMissing(
@@ -101,7 +106,7 @@ const Section3A = ({ title, subtitle, subsectionData }) => (
                                 </TableRow>
                                 <TableRow>
                                     <ReportCell>
-                                        % Region with poor score
+                                        {`Percent of ${orgUnitLevelName}s with divergent score`}
                                     </ReportCell>
                                     <ReportCell>
                                         {isNotMissing(
@@ -139,6 +144,7 @@ const Section3A = ({ title, subtitle, subsectionData }) => (
 )
 
 Section3A.propTypes = {
+    reportParameters: PropTypes.object,
     subsectionData: PropTypes.array,
     subtitle: PropTypes.string,
     title: PropTypes.string,
@@ -174,6 +180,7 @@ export const SectionThree = ({ reportParameters }) => {
             <Section3A
                 title={sectionInformation.section3a.title}
                 subtitle={sectionInformation.section3a.subtitle}
+                reportParameters={reportParameters}
                 subsectionData={section3Data.section3a}
             />
         )

--- a/src/components/annual-report/section4/SectionFour.js
+++ b/src/components/annual-report/section4/SectionFour.js
@@ -66,7 +66,12 @@ Section4A.propTypes = {
     title: PropTypes.string,
 }
 
-const Section4B = ({ title, subtitle, subsectionData }) => (
+const Section4B = ({
+    title,
+    subtitle,
+    subsectionData,
+    reportParameters: { orgUnitLevelName },
+}) => (
     <>
         <ReportTable className={styles.marginBottom4}>
             <TableHead>
@@ -109,7 +114,7 @@ const Section4B = ({ title, subtitle, subsectionData }) => (
                                 </TableRow>
                                 <TableRow>
                                     <ReportCell>
-                                        # Region with poor score
+                                        {`Numer of ${orgUnitLevelName}s with divergent score`}
                                     </ReportCell>
                                     <ReportCell>
                                         {dataRow.divergentSubOrgUnits?.number}
@@ -117,7 +122,7 @@ const Section4B = ({ title, subtitle, subsectionData }) => (
                                 </TableRow>
                                 <TableRow>
                                     <ReportCell>
-                                        % Region with poor score
+                                        {`Percent of ${orgUnitLevelName}s with divergent score`}
                                     </ReportCell>
                                     <ReportCell>
                                         {
@@ -147,6 +152,7 @@ const Section4B = ({ title, subtitle, subsectionData }) => (
 )
 
 Section4B.propTypes = {
+    reportParameters: PropTypes.object,
     subsectionData: PropTypes.array,
     subtitle: PropTypes.string,
     title: PropTypes.string,
@@ -183,6 +189,7 @@ export const SectionFour = ({ reportParameters }) => {
                     title={sectionInformation.section4b.title}
                     subtitle={sectionInformation.section4b.subtitle}
                     subsectionData={section4Data.section4b}
+                    reportParameters={reportParameters}
                 />
             </>
         )

--- a/src/components/report-parameter-selector/OrgUnitSelector.js
+++ b/src/components/report-parameter-selector/OrgUnitSelector.js
@@ -11,19 +11,12 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import styles from './OrgUnitSelector.module.css'
 
-const getSelectionLabel = ({
-    selectedOrgUnit,
-    selectedOrgUnitLevel,
-    orgUnitLevels,
-}) => {
+const getSelectionLabel = ({ selectedOrgUnit, selectedOrgUnitLevel }) => {
     let label = ''
     label += selectedOrgUnit.displayName ?? ''
     label += label && selectedOrgUnitLevel ? '; ' : ''
     if (selectedOrgUnitLevel) {
-        const orgUnitLevelName = orgUnitLevels.find(
-            ({ level }) => String(level) === selectedOrgUnitLevel
-        )?.displayName
-        label += orgUnitLevelName
+        label += selectedOrgUnitLevel.displayName
     }
     return label
 }
@@ -88,10 +81,15 @@ export const OrgUnitSelector = ({
                     </Field>
                     <SingleSelectField
                         label={i18n.t('Choose an organisation unit level')}
-                        selected={selectedOrgUnitLevel ?? ''}
-                        onChange={({ selected }) =>
-                            setSelectedOrgUnitLevel(selected)
-                        }
+                        // format `selected` as just the ID so it's a string
+                        selected={selectedOrgUnitLevel?.id ?? ''}
+                        // parse the selected ID to save the full object in state
+                        onChange={({ selected }) => {
+                            const newSelected = orgUnitLevels.find(
+                                (level) => level.id === selected
+                            )
+                            setSelectedOrgUnitLevel(newSelected)
+                        }}
                     >
                         {orgUnitLevels
                             .filter(({ level }) => {
@@ -99,10 +97,10 @@ export const OrgUnitSelector = ({
                                     level > Number(selectedOrgUnit?.level ?? 1)
                                 )
                             })
-                            .map(({ id, displayName, level }) => (
+                            .map(({ id, displayName }) => (
                                 <SingleSelectOption
                                     key={id}
-                                    value={String(level)}
+                                    value={id}
                                     label={displayName}
                                 />
                             ))}
@@ -126,7 +124,11 @@ OrgUnitSelector.propTypes = {
     orgUnitLevels: PropTypes.array,
     rootOrgUnitsInfo: PropTypes.array,
     selectedOrgUnit: PropTypes.object,
-    selectedOrgUnitLevel: PropTypes.string,
+    selectedOrgUnitLevel: PropTypes.shape({
+        displayName: PropTypes.string,
+        id: PropTypes.string,
+        level: PropTypes.number,
+    }),
     setSelectedOrgUnit: PropTypes.func,
     setSelectedOrgUnitLevel: PropTypes.func,
 }

--- a/src/components/report-parameter-selector/getReportParameters.js
+++ b/src/components/report-parameter-selector/getReportParameters.js
@@ -26,8 +26,9 @@ export const getReportParameters = ({
 
     const reportParameters = {
         orgUnits: [orgUnitID],
-        orgUnitLevel: `LEVEL-${orgUnitLevel}`,
-        orgUnitLevelNumber: orgUnitLevel,
+        orgUnitLevel: `LEVEL-${orgUnitLevel.level}`,
+        orgUnitLevelNumber: orgUnitLevel.level,
+        orgUnitLevelName: orgUnitLevel.displayName,
         boundaryOrgUnitLevel,
         groupID: groupID,
         // note that `periods[0]` is the current period


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/RWDQA-72

Refactors the org unit select to save the whole `organisationUnitLevel` object. In `reportParameters`, instead of restructuring the object, just a `orgUnitLevelName` property is added to maintain backwards compatibility.

Then some sections take the `reportParameters` and add the `orgUnitLevelName` to their text. I also added a few dynamic period names and reference year numbers to some descriptions.

In section 2, I refactored the `subtitle` of some section info objects to be a function to take an argument without restructuring the components much

![Screenshot 2023-11-19 at 1 42 52 PM](https://github.com/hisprwanda/who-data-quality-annual-report/assets/49666798/b9ab3893-46e2-43d3-bc7a-990de25562ea)
