### PR TITLE
fix: clear invalid org unit level [RWDQA-91]

### DIFF
--- a/src/components/report-parameter-selector/OrgUnitSelector.js
+++ b/src/components/report-parameter-selector/OrgUnitSelector.js
@@ -59,7 +59,7 @@ export const OrgUnitSelector = ({
                                     // clear out selected level if selected org unit is too low
                                     if (
                                         selectedOrgUnitLevel &&
-                                        Number(selectedOrgUnitLevel) <=
+                                        Number(selectedOrgUnitLevel.level) <=
                                             computedLevel
                                     ) {
                                         setSelectedOrgUnitLevel(null)


### PR DESCRIPTION
See: https://dhis2.atlassian.net/browse/RWDQA-91

This fixes an issue that was introduced when we updated the logic on the Org Unit Level selection.

This update will make the OrgUnitLevel clear out properly when a new Org Unit is selected.