### PR TITLE
fix: section 2E issues [RWDQA-93]

### DIFF
--- a/src/components/annual-report/section2/SectionTwo.js
+++ b/src/components/annual-report/section2/SectionTwo.js
@@ -271,11 +271,11 @@ const Section2EBlock = ({
             </TableHead>
             <TableBody>
                 <TableRow>
-                    <ReportCell>Denominator A</ReportCell>
+                    <ReportCell>Indicator A</ReportCell>
                     <ReportCell>{dataRow.A}</ReportCell>
                 </TableRow>
                 <TableRow>
-                    <ReportCell>Denominator B</ReportCell>
+                    <ReportCell>Indicator B</ReportCell>
                     <ReportCell>{dataRow.B}</ReportCell>
                 </TableRow>
                 <TableRow>

--- a/src/components/annual-report/section2/section2eCalculations.js
+++ b/src/components/annual-report/section2/section2eCalculations.js
@@ -34,7 +34,7 @@ const isDivergent2e = ({ type, score, overallScore, criteria }) => {
     }
     if (type === 'level') {
         return (
-            score < (1 + criteria / 100) * overallScore ||
+            score < (1 - criteria / 100) * overallScore ||
             score > (1 + criteria / 100) * overallScore
         )
     }
@@ -61,7 +61,7 @@ const getSection2EChartInfoBasic = ({
     }
     return {
         type: 'scatter',
-        slope: type === 'level' ? overallScore / 100 : 1,
+        slope: type === 'level' ? overallScore : 1,
         threshold: criteria,
         xAxisTitle: metadata[B]?.name,
         yAxisTitle: metadata[A]?.name,
@@ -197,6 +197,7 @@ const calculateSection2e = ({
                         100,
                     1
                 ),
+                names: divergentSubOrgUnits.sort().join(', '),
             },
             chartInfo,
         })


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/RWDQA-93

Fixes some issues from Section 2E:

- Tables say “Denominators” when they should say “Indicators
- Divergent region names aren’t shown in the table
- “Equal across org units” graph line doesn’t look right (slope is incorrect)
- “Equal across org units” divergent calculations are incorrect

These are now fixed, example:
<img width="1195" alt="image" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/18490902/4e03ae73-82af-483f-940a-3eda3922abf3">
