### PR TITLE
fix: margins around "no data" info boxes [RWDQA-97]

### DIFF
--- a/src/components/annual-report/ReportData.js
+++ b/src/components/annual-report/ReportData.js
@@ -35,7 +35,9 @@ export const ReportData = ({ reportParameters }) => {
         <div className={styles.reportContainer}>
             <SectionLayout title="Domain 1 - Completeness of Reporting">
                 {isSectionOneEmpty ? (
-                    <NoDataInfoBox subsection={false} />
+                    <div className={styles.marginBottom24}>
+                        <NoDataInfoBox subsection={false} />
+                    </div>
                 ) : (
                     <SectionOne reportParameters={reportParameters} />
                 )}
@@ -48,7 +50,9 @@ export const ReportData = ({ reportParameters }) => {
                     ?.length > 0 ? (
                     <SectionThree reportParameters={reportParameters} />
                 ) : (
-                    <NoDataInfoBox subsection={false} />
+                    <div className={styles.marginBottom24}>
+                        <NoDataInfoBox subsection={false} />
+                    </div>
                 )}
             </SectionLayout>
             <SectionLayout title="Domain 4 - Consistency of Population Data">
@@ -56,7 +60,9 @@ export const ReportData = ({ reportParameters }) => {
                     ?.length > 0 ? (
                     <SectionFour reportParameters={reportParameters} />
                 ) : (
-                    <NoDataInfoBox subsection={false} />
+                    <div className={styles.marginBottom24}>
+                        <NoDataInfoBox subsection={false} />
+                    </div>
                 )}
             </SectionLayout>
         </div>

--- a/src/components/annual-report/ReportData.module.css
+++ b/src/components/annual-report/ReportData.module.css
@@ -4,6 +4,10 @@
     background-color: white;
 }
 
+.marginBottom24 {
+    margin-bottom: 24px;
+}
+
 .sectionHeading {
     background: var(--colors-blue400);
     padding: 8px;

--- a/src/components/annual-report/section2/SectionTwo.js
+++ b/src/components/annual-report/section2/SectionTwo.js
@@ -73,8 +73,8 @@ const Sections2a2b2c = ({
 
     if (subsectionData.length === 0) {
         return (
-            <div className={styles.section2abcContainer}>
-                <ReportTable>
+            <div className={styles.marginBottom24}>
+                <ReportTable className={styles.marginBottom4}>
                     <TableHead>
                         <SubSectionLayout
                             title={title}
@@ -88,7 +88,7 @@ const Sections2a2b2c = ({
     }
 
     return (
-        <div className={styles.section2abcContainer}>
+        <div className={styles.marginBottom24}>
             <ReportTable className={styles.marginBottom4}>
                 <TableHead>
                     <SubSectionLayout
@@ -238,7 +238,11 @@ const Section2D = ({ title, subtitle, subsectionData, reportParameters }) => (
                 />
             </TableHead>
         </ReportTable>
-        {subsectionData.length === 0 && <NoDataInfoBox subsection={true} />}
+        {subsectionData.length === 0 && (
+            <div className={styles.marginBottom24}>
+                <NoDataInfoBox subsection={true} />
+            </div>
+        )}
         {subsectionData.map((dataRow, index) => (
             <Section2DBlock
                 key={dataRow.name}
@@ -346,7 +350,11 @@ const Section2E = ({ title, subtitle, subsectionData, reportParameters }) => (
                 <SubSectionLayout title={title} subtitle={subtitle} />
             </TableHead>
         </ReportTable>
-        {subsectionData.length === 0 && <NoDataInfoBox subsection={true} />}
+        {subsectionData.length === 0 && (
+            <div className={styles.marginBottom24}>
+                <NoDataInfoBox subsection={true} />
+            </div>
+        )}
         {subsectionData.map((dataRow, index) => (
             <Section2EBlock
                 key={dataRow.title}
@@ -405,7 +413,11 @@ export const SectionTwo = ({ reportParameters }) => {
                 )
                 .every((subsectionLength) => subsectionLength === 0)
         ) {
-            return <NoDataInfoBox subsection={false} />
+            return (
+                <div className={styles.marginBottom24}>
+                    <NoDataInfoBox subsection={false} />
+                </div>
+            )
         }
 
         return (

--- a/src/components/annual-report/section2/SectionTwo.module.css
+++ b/src/components/annual-report/section2/SectionTwo.module.css
@@ -1,5 +1,4 @@
-/* Section 2a-c */
-.section2abcContainer {
+.marginBottom24 {
     margin-bottom: 24px;
 }
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/RWDQA-97

Adds some margins to make them look better -- "no data" is simulated in these demos:
![main-sections](https://github.com/hisprwanda/who-data-quality-annual-report/assets/49666798/ca17c015-c5b3-4f69-a13d-e56abe5121f0)


![section-2-subsections](https://github.com/hisprwanda/who-data-quality-annual-report/assets/49666798/b4d1d7ed-4cd2-44de-b2e4-7c469baf2caa)
