### PR TITLE
fix: issues with skipTotal categoryCombo [RWDQA-92]

### DIFF
--- a/src/components/annual-report/section1/section1Calculations.js
+++ b/src/components/annual-report/section1/section1Calculations.js
@@ -3,11 +3,7 @@ import {
     getMean,
     getRoundedValue,
 } from '../utils/mathService.js'
-import {
-    convertAnalyticsResponseToObject,
-    getVal,
-    getValCO,
-} from '../utils/utils.js'
+import { convertAnalyticsResponseToObject, getVal } from '../utils/utils.js'
 
 // gets a list of retions in which the reporting rate score was lower than the threshold
 const getRegionsWithLowScore = (filterd_datasets, key) => {
@@ -481,8 +477,8 @@ const getExpectedValues = ({ numerator, response, pe, ou }) => {
     }, 0)
 }
 
-const getActualValue1C = ({ response, dx, co, pe, ou }) => {
-    return getValCO({ response, dx, co, ou, pe })
+const getActualValue1C = ({ response, dx, pe, ou }) => {
+    return getVal({ response, dx, ou, pe })
 }
 
 const calculateSection1C = ({
@@ -493,7 +489,6 @@ const calculateSection1C = ({
     mappedConfigurations,
     period,
     overallOrgUnit,
-    defaultCOC,
 }) => {
     const section1C = []
 
@@ -527,15 +522,13 @@ const calculateSection1C = ({
         //  get overall values
         const numerator = mappedConfigurations.dataElementsAndIndicators[de]
         const threshold = numerator.missing
-        const [deID = de, cocID = defaultCOC] =
-            numerator.dataElementOperandID?.split('.')
+        const dataElementOperand = numerator.dataElementOperandID
 
         const actualValues = getActualValue1C({
             response: overall_counts,
             pe: period,
             ou: overallOrgUnit,
-            dx: deID,
-            co: cocID,
+            dx: dataElementOperand,
         })
         const expectedValues = getExpectedValues({
             response: overall_expected_reports,
@@ -555,8 +548,7 @@ const calculateSection1C = ({
                 response: by_level_counts,
                 pe: period,
                 ou: subOrgUnit,
-                dx: deID,
-                co: cocID,
+                dx: dataElementOperand,
             })
             const expectedSubOrgUnit = getExpectedValues({
                 response: by_level_expected_reports,
@@ -576,11 +568,7 @@ const calculateSection1C = ({
             expectedValues,
             actualValues,
             overallScore,
-            indicator_name: `${metadata[deID]?.name} ${
-                cocID && cocID !== defaultCOC
-                    ? '(' + metadata[cocID]?.name + ')'
-                    : ''
-            }`,
+            indicator_name: metadata[dataElementOperand]?.name,
             orgUnitLevelsOrGroups: divergentSubOrgUnits
                 .map((ouID) => metadata[ouID]?.name)
                 .sort(),
@@ -607,7 +595,6 @@ export const calculateSection1 = ({
     period,
     periodsIDs,
     overallOrgUnit,
-    defaultCOC,
 }) => {
     if (!reportQueryResponse || !mappedConfigurations) {
         return {}
@@ -644,7 +631,6 @@ export const calculateSection1 = ({
             mappedConfigurations,
             period: period,
             overallOrgUnit,
-            defaultCOC,
         }),
         section1D: getConsistencyOfDatasetCompletenessData({
             allOrgUnitsData:


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/RWDQA-92

This PR fixes cases where requests were failing because an underlying category combo was designated skipTotals: true (I'm not sure why these requests would fail given that we were not requesting the total counts, but rather the counts disaggregated by category option combo 🤷‍♂️, but we can do these requesst differently and avoid the issue).

This fix uses data element operand directly as a dx request. Since we are now requiring all numerators to have a data element operand (and filtering them out if they don't), this should not pose an issue (and is simpler than what I previously implemented, which did the request with `co` as a parameter, which then necessitated some additional work for handling defaults)

(Tested with https://online.hisprwanda.org/hmisdev, General Service Statistics group)

**Before:**
<img width="1397" alt="image" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/18490902/c593ef96-6efb-40f9-95e6-aebbe42314d9">


**After:**
<img width="1389" alt="image" src="https://github.com/hisprwanda/who-data-quality-annual-report/assets/18490902/b008af67-ccf0-41ad-b4ac-921b07c6cb70">



