### PR TITLE
feat: validate that the group name is unique while creating it

### DIFF
--- a/src/components/config-tabs/numerator-groups/EditGroupModal.js
+++ b/src/components/config-tabs/numerator-groups/EditGroupModal.js
@@ -16,6 +16,7 @@ import {
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { validateUniqueConfigObjectName } from '../../../utils/configurations/validateUniqueConfigObjectName.js'
 import { useConfigurations } from '../../../utils/index.js'
 
 const { Form, Field } = ReactFinalForm
@@ -42,7 +43,22 @@ export function EditGroupModal({ groupToEdit, onSave, onClose }) {
         <Form
             onSubmit={(values) => {
                 if (onSave) {
-                    onSave(values)
+                    // validate that the group name is unique while creating a new group
+                    if (!groupToEdit) {
+                        const isUnique = validateUniqueConfigObjectName(
+                            values.name,
+                            'groups',
+                            configurations
+                        )
+                        if (isUnique) {
+                            onSave(values)
+                        } else {
+                            alert('Group name is not unique')
+                        }
+                    } else {
+                        // if we are not editing an existing group, no need to check if the name is unique
+                        onSave(values)
+                    }
                 } else {
                     alert('todo')
                 }

--- a/src/utils/configurations/validateUniqueConfigObjectName.js
+++ b/src/utils/configurations/validateUniqueConfigObjectName.js
@@ -1,0 +1,68 @@
+/**
+ * Returns true if the newConfigName is unique accross the particular configuration object & false if not
+ * This check can be done for objects that are created with a name
+ * i.e: numerators, numerator groups, numerator relations, denominator relations, and external data comparisons
+ */
+export function validateUniqueConfigObjectName(
+    newObjectName,
+    objectType,
+    configurations
+) {
+    switch (objectType) {
+        // case 'numerators': {
+        // // check if there are any numerators
+        // if (
+        //     !configurations.numerators ||
+        //     configurations.numerators.length === 0
+        // ) {
+        //     return true
+        // }
+        // // check if the new numerator name is unique
+        // const existingNumerator = configurations.numerators.find(
+        //     (numerator) =>
+        //         numerator.name.toLowerCase() === newObjectName.toLowerCase()
+        // )
+        // if (existingNumerator) {
+        //     return false
+        // }
+        // return true
+        // }
+        case 'groups': {
+            // check if there are any groups
+            if (!configurations.groups || configurations.groups.length === 0) {
+                return true
+            }
+            // check if the new group name is unique
+            const existingGroup = configurations.groups.find(
+                (group) =>
+                    group.name.toLowerCase() === newObjectName.toLowerCase()
+            )
+            if (existingGroup) {
+                return false
+            }
+            return true
+        }
+        // case 'numeratorRelations': {
+        // // check if there are any numerator relations
+        // if (
+        //     !configurations.numeratorRelations ||
+        //     configurations.numeratorRelations.length === 0
+        // ) {
+        //     return true
+        // }
+        // // check if the new numerator relation name is unique
+        // const existingNumeratorRelation =
+        //     configurations.numeratorRelations.find(
+        //         (numeratorRelation) =>
+        //             numeratorRelation.name.toLowerCase() ===
+        //             newObjectName.toLowerCase()
+        //     )
+        // if (existingNumeratorRelation) {
+        //     return false
+        // }
+        // return true
+        // }
+        default:
+            return true
+    }
+}


### PR DESCRIPTION
This PR addresses the issue where configuration objects might be created with duplicated names. 
Currently the `groups` object is done. 
This are the configuration objects that are created with a name (requires the user to type the name)
These objects are: numerators, numerator groups, numerator relations, denominator relations, and external data comparisons
 
- [ ] Validate group name's uniqueness
- [ ] Validate numerator name 
- [ ] Validate numerator group name
- [ ] Validate numerator relation name
- [ ] Validate denominator relation name
- [ ] Validate external data comparisons name
- [ ] Apply the validation to other components
