### PR TITLE
fix: validate denominator's relations with other objects before delete [RWDQA-101]

### DIFF
--- a/src/components/config-tabs/denominators/DenominatorTableItem.js
+++ b/src/components/config-tabs/denominators/DenominatorTableItem.js
@@ -84,60 +84,57 @@ const DeleteDenominatorButton = ({ denominator }) => {
         [dispatch, denominator.code]
     )
 
-    // Check to see if this numerator is used in any other metadata same as it is done for numerators
+    // Check to see if this denominator is used in any other metadata same as it is done for numerators
     // denominator relations or external relations and warn the user if so
     /**
      * //TODO: this is a copy of the same function in NumeratorTableItem.js,
      * so it should be refactored into a shared function and use switch statements to determine which metadata to check
      *  */
-    const validateDenominatorDeletion = useCallback(
-        (object) => {
-            const associatedDenominatorRelations = []
-            configurations.denominatorRelations.forEach((relation) => {
-                const { A, B, name } = relation
-                if (A === denominator.code || B === denominator.code) {
-                    associatedDenominatorRelations.push(name)
-                }
-            })
-
-            const associatedExternalRelations = []
-            configurations.externalRelations.forEach((relation) => {
-                if (relation.denominator === denominator.code) {
-                    associatedExternalRelations.push(relation.name)
-                }
-            })
-
-            if (
-                associatedDenominatorRelations.length === 0 &&
-                associatedExternalRelations.length === 0
-            ) {
-                // then no problem; this deletion is valid
-                return true
+    const validateDenominatorDeletion = useCallback(() => {
+        const associatedDenominatorRelations = []
+        configurations.denominatorRelations.forEach((relation) => {
+            const { A, B, name } = relation
+            if (A === denominator.code || B === denominator.code) {
+                associatedDenominatorRelations.push(name)
             }
+        })
 
-            // Otherwise, warn the user
-            const numRelsText =
-                associatedDenominatorRelations.length > 0
-                    ? '\nDenominator relations: ' +
-                      associatedDenominatorRelations.join(', ') +
-                      '.'
-                    : ''
-            const extRelsText =
-                associatedExternalRelations.length > 0
-                    ? '\nExternal relations: ' +
-                      associatedExternalRelations.join(', ') +
-                      '.'
-                    : ''
-            const message =
-                `Can't delete the denominator "${denominator.name}" because it's ` +
-                `associated with the following metadata.` +
-                numRelsText +
-                extRelsText
-            show({ message })
-            return false
-        },
-        [configurations, denominator, show]
-    )
+        const associatedExternalRelations = []
+        configurations.externalRelations.forEach((relation) => {
+            if (relation.denominator === denominator.code) {
+                associatedExternalRelations.push(relation.name)
+            }
+        })
+
+        if (
+            associatedDenominatorRelations.length === 0 &&
+            associatedExternalRelations.length === 0
+        ) {
+            // then no problem; this deletion is valid
+            return true
+        }
+
+        // Otherwise, warn the user
+        const numRelsText =
+            associatedDenominatorRelations.length > 0
+                ? '\nDenominator relations: ' +
+                  associatedDenominatorRelations.join(', ') +
+                  '.'
+                : ''
+        const extRelsText =
+            associatedExternalRelations.length > 0
+                ? '\nExternal relations: ' +
+                  associatedExternalRelations.join(', ') +
+                  '.'
+                : ''
+        const message =
+            `Can't delete the denominator "${denominator.name}" because it's ` +
+            `associated with the following metadata.` +
+            numRelsText +
+            extRelsText
+        show({ message })
+        return false
+    }, [configurations, denominator, show])
 
     return (
         <>
@@ -145,7 +142,7 @@ const DeleteDenominatorButton = ({ denominator }) => {
                 small
                 destructive
                 onClick={() => {
-                    if (validateDenominatorDeletion('denominator')) {
+                    if (validateDenominatorDeletion()) {
                         openModal()
                     }
                 }}

--- a/src/components/config-tabs/denominators/DenominatorTableItem.js
+++ b/src/components/config-tabs/denominators/DenominatorTableItem.js
@@ -1,3 +1,4 @@
+import { useAlert } from '@dhis2/app-runtime'
 import { Button, TableCell, TableRow, ButtonStrip } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useMemo, useCallback, useState } from 'react'
@@ -5,6 +6,7 @@ import { getDenominatorType } from '../../../utils/denominatorsMetadataData.js'
 import {
     DELETE_DENOMINATOR,
     UPDATE_DENOMINATOR,
+    useConfigurations,
     useConfigurationsDispatch,
     useDataItemNames,
 } from '../../../utils/index.js'
@@ -65,6 +67,8 @@ EditDenominatorButton.propTypes = {
 
 const DeleteDenominatorButton = ({ denominator }) => {
     const [confirmationModalOpen, setConfirmationModalOpen] = useState(false)
+    const configurations = useConfigurations()
+    const { show } = useAlert(({ message }) => message, { critical: true })
     const dataItemNames = useDataItemNames()
     const dispatch = useConfigurationsDispatch()
 
@@ -80,13 +84,70 @@ const DeleteDenominatorButton = ({ denominator }) => {
         [dispatch, denominator.code]
     )
 
+    // Check to see if this numerator is used in any other metadata same as it is done for numerators
+    // denominator relations or external relations and warn the user if so
+    /**
+     * //TODO: this is a copy of the same function in NumeratorTableItem.js,
+     * so it should be refactored into a shared function and use switch statements to determine which metadata to check
+     *  */
+    const validateDenominatorDeletion = useCallback(
+        (object) => {
+            const associatedDenominatorRelations = []
+            configurations.denominatorRelations.forEach((relation) => {
+                const { A, B, name } = relation
+                if (A === denominator.code || B === denominator.code) {
+                    associatedDenominatorRelations.push(name)
+                }
+            })
+
+            const associatedExternalRelations = []
+            configurations.externalRelations.forEach((relation) => {
+                if (relation.denominator === denominator.code) {
+                    associatedExternalRelations.push(relation.name)
+                }
+            })
+
+            if (
+                associatedDenominatorRelations.length === 0 &&
+                associatedExternalRelations.length === 0
+            ) {
+                // then no problem; this deletion is valid
+                return true
+            }
+
+            // Otherwise, warn the user
+            const numRelsText =
+                associatedDenominatorRelations.length > 0
+                    ? '\nDenominator relations: ' +
+                      associatedDenominatorRelations.join(', ') +
+                      '.'
+                    : ''
+            const extRelsText =
+                associatedExternalRelations.length > 0
+                    ? '\nExternal relations: ' +
+                      associatedExternalRelations.join(', ') +
+                      '.'
+                    : ''
+            const message =
+                `Can't delete the denominator "${denominator.name}" because it's ` +
+                `associated with the following metadata.` +
+                numRelsText +
+                extRelsText
+            show({ message })
+            return false
+        },
+        [configurations, denominator, show]
+    )
+
     return (
         <>
             <Button
                 small
                 destructive
                 onClick={() => {
-                    openModal()
+                    if (validateDenominatorDeletion('denominator')) {
+                        openModal()
+                    }
                 }}
             >
                 Delete


### PR DESCRIPTION
This PR, implements the same validation done on numerators before deletion. 
In case the denominator to be deleted is associated with another object the user should be warned before they delete it. 

Jira Ticket: https://dhis2.atlassian.net/jira/software/c/projects/RWDQA/boards/137?assignee=5c51f72f3e729341b3517497&selectedIssue=RWDQA-101