### PR TITLE
fix: issues with default configurations

### DIFF
--- a/src/components/config-tabs/denominators/DenominatorTableItem.js
+++ b/src/components/config-tabs/denominators/DenominatorTableItem.js
@@ -8,7 +8,6 @@ import {
     UPDATE_DENOMINATOR,
     useConfigurations,
     useConfigurationsDispatch,
-    useDataItemNames,
 } from '../../../utils/index.js'
 import { ConfirmationModal } from '../ConfirmationModal.js'
 import { EditDenominatorModal } from './EditDenominatorModal.js'
@@ -69,7 +68,6 @@ const DeleteDenominatorButton = ({ denominator }) => {
     const [confirmationModalOpen, setConfirmationModalOpen] = useState(false)
     const configurations = useConfigurations()
     const { show } = useAlert(({ message }) => message, { critical: true })
-    const dataItemNames = useDataItemNames()
     const dispatch = useConfigurationsDispatch()
 
     const openModal = useCallback(() => setConfirmationModalOpen(true), [])
@@ -152,9 +150,9 @@ const DeleteDenominatorButton = ({ denominator }) => {
             {confirmationModalOpen && (
                 <ConfirmationModal
                     title="Delete denominator"
-                    text={`Are you sure you want to delete ${dataItemNames.get(
-                        denominator.dataID
-                    )}?`}
+                    text={`Are you sure you want to delete ${
+                        denominator.name ?? denominator.code
+                    }?`}
                     action="Delete"
                     destructive
                     onClose={closeModal}
@@ -169,15 +167,13 @@ DeleteDenominatorButton.propTypes = {
 }
 
 export const DenominatorTableItem = ({ denominator }) => {
-    const dataItemNames = useDataItemNames()
-
     const denominatorType = React.useMemo(() => {
         return getDenominatorType(denominator.type).label
     }, [denominator])
 
     return (
         <TableRow>
-            <TableCell dense>{dataItemNames.get(denominator.dataID)}</TableCell>
+            <TableCell dense>{denominator.name ?? denominator.code}</TableCell>
             <TableCell dense>{denominatorType}</TableCell>
 
             <TableCell dense>

--- a/src/components/config-tabs/denominators/Denominators.js
+++ b/src/components/config-tabs/denominators/Denominators.js
@@ -69,10 +69,7 @@ export const Denominators = () => {
                 <Table>
                     <TableHead>
                         <TableRowHead>
-                            <TableCellHead>
-                                {' '}
-                                Data element/indicator{' '}
-                            </TableCellHead>
+                            <TableCellHead>Name</TableCellHead>
                             <TableCellHead>Type</TableCellHead>
                             <TableCellHead>Actions</TableCellHead>
                         </TableRowHead>

--- a/src/components/config-tabs/external-data-comparison/DenominatorSelect.js
+++ b/src/components/config-tabs/external-data-comparison/DenominatorSelect.js
@@ -11,11 +11,11 @@ export const DenominatorSelect = () => {
     // filter denominators that have data IDs & sort alphabetically
 
     const denominatorOptions = React.useMemo(() => {
-        const denominatorsWithDataIds = configurations.denominators
-            .filter((denominator) => denominator.dataID != null)
-            .sort((a, b) => a.name.localeCompare(b.name))
+        const denominatorsWithDataIds = [...configurations.denominators].sort(
+            (a, b) => a.name?.localeCompare(b.name)
+        )
         return denominatorsWithDataIds.map(({ name, code }) => ({
-            label: name,
+            label: name ?? code,
             value: code,
         }))
     }, [configurations.denominators])

--- a/src/components/config-tabs/external-data-comparison/ExternalDataComparisonTableItem.js
+++ b/src/components/config-tabs/external-data-comparison/ExternalDataComparisonTableItem.js
@@ -118,9 +118,10 @@ export function ExternalDataComparisonTableItem({
         if (ouLevelData) {
             const level = ouLevelData.orgUnitLevels.organisationUnitLevels.find(
                 (level) =>
-                    level.level.toString() === externalRelation.level.toString()
+                    level.level?.toString() ===
+                    externalRelation.level?.toString()
             )
-            return level.displayName
+            return level?.displayName
         } else {
             return ''
         }

--- a/src/components/config-tabs/external-data-comparison/NumeratorSelect.js
+++ b/src/components/config-tabs/external-data-comparison/NumeratorSelect.js
@@ -10,9 +10,9 @@ export const NumeratorSelect = () => {
 
     // filter numerators that have data IDs & sort alphabetically
     const numeratorOptions = React.useMemo(() => {
-        const numeratorsWithDataIds = configurations.numerators
-            .filter((numerator) => numerator.dataID != null)
-            .sort((a, b) => a.name.localeCompare(b.name))
+        const numeratorsWithDataIds = [...configurations.numerators].sort(
+            (a, b) => a.name?.localeCompare(b.name)
+        )
         return numeratorsWithDataIds.map(({ name, code }) => ({
             label: name,
             value: code,

--- a/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
+++ b/src/components/config-tabs/numerator-relations/EditNumeratorRelationModal.js
@@ -50,10 +50,9 @@ export function EditNumeratorRelationModal({
 }) {
     const configurations = useConfigurations()
     const numeratorOptions = React.useMemo(() => {
-        const numeratorsWithDataIds = configurations.numerators
-            .filter((numerator) => numerator.dataID != null)
-            // sort is okay because filter() creates a copy
-            .sort((a, b) => a.name.localeCompare(b.name))
+        const numeratorsWithDataIds = [...configurations.numerators].sort(
+            (a, b) => a.name.localeCompare(b.name)
+        )
         return numeratorsWithDataIds.map(({ name, code }) => ({
             label: name,
             value: code,

--- a/src/components/config-tabs/tab-contents/DenominatorRelations.js
+++ b/src/components/config-tabs/tab-contents/DenominatorRelations.js
@@ -366,7 +366,8 @@ export const DenominatorRelations = ({ toggleState }) => {
                                                           ) => (
                                                               <SingleSelectOption
                                                                   label={
-                                                                      denominator.name
+                                                                      denominator.name ??
+                                                                      denominator.code
                                                                   }
                                                                   value={
                                                                       denominator.code
@@ -408,7 +409,8 @@ export const DenominatorRelations = ({ toggleState }) => {
                                                           ) => (
                                                               <SingleSelectOption
                                                                   label={
-                                                                      denominator.name
+                                                                      denominator.name ??
+                                                                      denominator.code
                                                                   }
                                                                   value={
                                                                       denominator.code

--- a/src/utils/denominatorsMetadataData.js
+++ b/src/utils/denominatorsMetadataData.js
@@ -18,7 +18,7 @@ export const getDenominatorRelations = (denominators, code) => {
         (denominator) => denominator.code == code
     )
     if (denominatorObj) {
-        return denominatorObj.name
+        return denominatorObj.name ?? denominatorObj.code
     }
 }
 


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/RWDQA-104.

Fixes some issues when using default configurations (this is testable on https://demos.dhis2.org/hmis_staging. You can use same login/password as demos.dhis2.org/dq)

**We were incorrectly assuming some metadata was available **
We had some logic in external relations that was populating a level name, but the level (having not been selected by user) did not have a name. Added in some additional optional chaining for this and a couple of similar items (e.g. problems with localeCompare)

**Filtering for numerators/denominators with IDs causes issues**
Since our default configurations have numerators/denominators selected (e.g. in numerator relations, denominator relations), but we were filtering the selects to only include items with data IDs, we got errors when going to edit (that is, the app would crash in dev mode because we had filtered out the selected value because the underlying numerator/denominator did not have an id). I've removed these filters because they a) cause problems and b) we filter out invalid relations (missing data IDs) at time of report generation

**Denominator name**
We added in denominator name in our configurations. However, our default configurations do not have names (which makes sense as they also do not have data IDs). I've cleaned the use of the name up to return code where name is not available (e.g. effectively code will function as name until user goes and defines their own name).